### PR TITLE
Fix error for non slot devices.

### DIFF
--- a/assets/45d/45drives-disks/assets/index.bbceb330.js
+++ b/assets/45d/45drives-disks/assets/index.bbceb330.js
@@ -23288,24 +23288,6 @@ function zfsAnimation(p5) {
     });
     return true;
   };
-  p5.showStorageGroupPeers = (cd, animationInfo, diskLocations2, y_offset = 0) => {
-    const currentDisk = animationInfo?.animation_disks?.[cd];
-    const group = animationInfo?.animation_groups?.[currentDisk?.group] || [];
-    if (!currentDisk || group.length < 2) {
-      return false;
-    }
-    group.forEach((dsk) => {
-      const diskName = dsk?.name || dsk;
-      if (diskName === cd)
-        return;
-      const dsk_idx = diskLocations2.findIndex((loc) => loc.BAY === diskName);
-      if (dsk_idx < 0 || !diskLocations2[dsk_idx]?.image)
-        return;
-      const loc = diskLocations2[dsk_idx];
-      p5.animateZpools(loc.x, loc.y, loc.image.width, loc.image.height + y_offset, p5.zfsAnimationSteps, p5.zfsAnimationIndex, p5.zfsAnimationColors.storage_group.start, p5.zfsAnimationColors.storage_group.end, p5.zfsAnimationDir);
-    });
-    return true;
-  };
   p5.showAnimations = (cd, zfsInfo, diskLocations2, y_offset = 0) => {
     if (zfsInfo.zfs_installed) {
       if (Array.isArray(zfsInfo.zpools) && zfsInfo.zfs_disks && zfsInfo.zfs_disks[cd]) {
@@ -23356,7 +23338,6 @@ function zfsAnimation(p5) {
               }
             });
           });
-          p5.showStorageGroupPeers(cd, zfsInfo, diskLocations2, y_offset);
           return true;
         }
       }

--- a/assets/45d/45drives-disks/assets/index.bbceb330.js
+++ b/assets/45d/45drives-disks/assets/index.bbceb330.js
@@ -23295,7 +23295,10 @@ function zfsAnimation(p5) {
       return false;
     }
     group.forEach((dsk) => {
-      const dsk_idx = diskLocations2.findIndex((loc) => loc.BAY === dsk.name);
+      const diskName = dsk?.name || dsk;
+      if (diskName === cd)
+        return;
+      const dsk_idx = diskLocations2.findIndex((loc) => loc.BAY === diskName);
       if (dsk_idx < 0 || !diskLocations2[dsk_idx]?.image)
         return;
       const loc = diskLocations2[dsk_idx];

--- a/assets/45d/45drives-disks/assets/index.bbceb330.js
+++ b/assets/45d/45drives-disks/assets/index.bbceb330.js
@@ -23288,6 +23288,21 @@ function zfsAnimation(p5) {
     });
     return true;
   };
+  p5.showStorageGroupPeers = (cd, animationInfo, diskLocations2, y_offset = 0) => {
+    const currentDisk = animationInfo?.animation_disks?.[cd];
+    const group = animationInfo?.animation_groups?.[currentDisk?.group] || [];
+    if (!currentDisk || group.length < 2) {
+      return false;
+    }
+    group.forEach((dsk) => {
+      const dsk_idx = diskLocations2.findIndex((loc) => loc.BAY === dsk.name);
+      if (dsk_idx < 0 || !diskLocations2[dsk_idx]?.image)
+        return;
+      const loc = diskLocations2[dsk_idx];
+      p5.animateZpools(loc.x, loc.y, loc.image.width, loc.image.height + y_offset, p5.zfsAnimationSteps, p5.zfsAnimationIndex, p5.zfsAnimationColors.storage_group.start, p5.zfsAnimationColors.storage_group.end, p5.zfsAnimationDir);
+    });
+    return true;
+  };
   p5.showAnimations = (cd, zfsInfo, diskLocations2, y_offset = 0) => {
     if (zfsInfo.zfs_installed) {
       if (Array.isArray(zfsInfo.zpools) && zfsInfo.zfs_disks && zfsInfo.zfs_disks[cd]) {
@@ -23338,6 +23353,7 @@ function zfsAnimation(p5) {
               }
             });
           });
+          p5.showStorageGroupPeers(cd, zfsInfo, diskLocations2, y_offset);
           return true;
         }
       }

--- a/php/zfs_info.php
+++ b/php/zfs_info.php
@@ -73,6 +73,17 @@ function zfs_drivemap_lookup()
         $lookup[$value] = $bay_id;
         $lookup[basename($value)] = $bay_id;
       }
+
+      $storage_label = $slot['storage-label'] ?? '';
+      if (is_string($storage_label) && preg_match('/^disk([0-9]+)$/', $storage_label, $match)) {
+        $lookup[$storage_label] = $bay_id;
+        $lookup['md' . $match[1]] = $bay_id;
+        $lookup['md' . $match[1] . 'p1'] = $bay_id;
+        $lookup['/dev/md' . $match[1]] = $bay_id;
+        $lookup['/dev/md' . $match[1] . 'p1'] = $bay_id;
+        $lookup['/dev/mapper/md' . $match[1]] = $bay_id;
+        $lookup['/dev/mapper/md' . $match[1] . 'p1'] = $bay_id;
+      }
     }
   }
 
@@ -401,54 +412,10 @@ function zpool_status_parse($status_obj, $key, $pool_name, $disk_lookup = [])
 
 function verify_zfs_device_format($status_obj, $pool_name, $disk_lookup = [])
 {
-  // Frontend drive-to-bay mapping relies on "card-drive" aliases (e.g. 1-1).
-  // Emit warnings when pool members do not follow that convention.
+  // Non-bay devices such as boot, flash, and standalone NVMe pools are valid
+  // ZFS members, but there is no slot to annotate in the drivemap UI.
+  // Keep them in the pool list and skip user-facing warnings.
   $alert = [];
-  if (!isset($status_obj[$pool_name])) {
-    return $alert;
-  }
-
-  $default_pattern = '/^\t    (\d+-\d+)(?:-part[0-9])?\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*/m';
-  $unsupported_pattern = '/^\t    (\S+)(?:-part[0-9])?\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*/m';
-
-  preg_match_all($default_pattern, $status_obj[$pool_name], $default_matches, PREG_SET_ORDER);
-  preg_match_all($unsupported_pattern, $status_obj[$pool_name], $unsupported_matches, PREG_SET_ORDER);
-
-  $default_disks = [];
-  foreach ($default_matches as $match) {
-    $default_disks[] = $match[1];
-  }
-
-  $unsupported_disks = [];
-  foreach ($unsupported_matches as $match) {
-    $unsupported_disks[] = $match[1];
-  }
-
-  if (count($unsupported_disks) > count($default_disks)) {
-    $filtered = array_values(array_diff($unsupported_disks, $default_disks));
-    $filtered = array_values(array_filter($filtered, function ($name) {
-      return !preg_match('/^(\d+-\d+)(?:-part[0-9])/', $name);
-    }));
-    $filtered = array_values(array_filter($filtered, function ($name) use ($disk_lookup) {
-      return !preg_match('/^\d+-\d+$/', canonical_zfs_disk_name($name, $disk_lookup));
-    }));
-
-    if (!$filtered) {
-      return $alert;
-    }
-
-    $alert[] = "ZFS status displayed by this module for zpool '$pool_name' may be incomplete.\n\n";
-    $alert[] = "This module can only display zfs status information for devices that are created using a device alias.\n\n";
-    $alert[] = "This can be done using the 45Drives cockpit-zfs-manager package:\nhttps://github.com/45Drives/cockpit-zfs-manager/releases/\n\n";
-    if ($filtered) {
-      $alert[] = "The following zfs devices do not conform:\n";
-      foreach ($filtered as $disk) {
-        $alert[] = "\t  $disk\n";
-      }
-    }
-    $alert[] = "\n";
-  }
-
   return $alert;
 }
 
@@ -624,6 +591,9 @@ function generate_zfs_info()
     }
     foreach ($pool['vdevs'] as $vdev) {
       foreach ($vdev['disks'] as $disk) {
+        if (!isset($disk['name']) || !preg_match('/^\d+-\d+$/', $disk['name'])) {
+          continue;
+        }
         $disk_entries[$disk['name']] = [
           'zpool_name' => $pool['name'],
           'zpool_used' => $pool['used'] ?? '-',

--- a/php/zfs_info.php
+++ b/php/zfs_info.php
@@ -418,11 +418,15 @@ function verify_zfs_device_format($status_obj, $pool_name, $disk_lookup = [])
     return $alert;
   }
 
-  preg_match_all('/^\t    (\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*/m', $status, $matches, PREG_SET_ORDER);
+  preg_match_all('/^\t(?:  |    )(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*/m', $status, $matches, PREG_SET_ORDER);
   $unsupported_disks = [];
   foreach ($matches as $match) {
     $name = $match[1];
-    if (preg_match('/^\d+-\d+(?:-part[0-9])?$/', $name)) {
+    if (preg_match('/^(mirror|raidz[0-9]?|draid[0-9]?|spare|log|logs|cache|special|dedup)-?[0-9]*$/', $name)) {
+      continue;
+    }
+
+    if (preg_match('/^\d+-\d+(?:-part[0-9]+)?$/', $name)) {
       continue;
     }
 
@@ -432,7 +436,7 @@ function verify_zfs_device_format($status_obj, $pool_name, $disk_lookup = [])
     }
 
     $base_name = basename($name);
-    if (preg_match('/^(boot|flash)(?:-part[0-9])?$/', $base_name) || preg_match('/^nvme[0-9]+n[0-9]+(?:p[0-9]+)?$/', $base_name)) {
+    if (preg_match('/^(boot|flash)(?:-part[0-9]+)?$/', $base_name) || preg_match('/^nvme[0-9]+n[0-9]+(?:p[0-9]+)?$/', $base_name)) {
       continue;
     }
 

--- a/php/zfs_info.php
+++ b/php/zfs_info.php
@@ -412,10 +412,48 @@ function zpool_status_parse($status_obj, $key, $pool_name, $disk_lookup = [])
 
 function verify_zfs_device_format($status_obj, $pool_name, $disk_lookup = [])
 {
-  // Non-bay devices such as boot, flash, and standalone NVMe pools are valid
-  // ZFS members, but there is no slot to annotate in the drivemap UI.
-  // Keep them in the pool list and skip user-facing warnings.
   $alert = [];
+  $status = $status_obj[$pool_name] ?? '';
+  if ($status === '') {
+    return $alert;
+  }
+
+  preg_match_all('/^\t    (\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*/m', $status, $matches, PREG_SET_ORDER);
+  $unsupported_disks = [];
+  foreach ($matches as $match) {
+    $name = $match[1];
+    if (preg_match('/^\d+-\d+(?:-part[0-9])?$/', $name)) {
+      continue;
+    }
+
+    $canonical_name = canonical_zfs_disk_name($name, $disk_lookup);
+    if (preg_match('/^\d+-\d+$/', $canonical_name)) {
+      continue;
+    }
+
+    $base_name = basename($name);
+    if (preg_match('/^(boot|flash)(?:-part[0-9])?$/', $base_name) || preg_match('/^nvme[0-9]+n[0-9]+(?:p[0-9]+)?$/', $base_name)) {
+      continue;
+    }
+
+    $unsupported_disks[] = [
+      'name' => $name,
+    ];
+  }
+
+  if (!$unsupported_disks) {
+    return $alert;
+  }
+
+  $alert[] = "ZFS status displayed by this module for zpool '{$pool_name}' may be incomplete.\n\n";
+  $alert[] = "This module can only display zfs status information for devices that are created using a device alias.\n\n";
+  $alert[] = "This can be done using the 45Drives cockpit-zfs-manager package:\nhttps://github.com/45Drives/cockpit-zfs-manager/releases/\n\n";
+  $alert[] = "The following zfs devices do not conform:\n";
+  foreach ($unsupported_disks as $disk) {
+    $alert[] = "\t  {$disk['name']}\n";
+  }
+  $alert[] = "\n";
+
   return $alert;
 }
 

--- a/tests/fixtures/zfs_array/zfs_list.txt
+++ b/tests/fixtures/zfs_array/zfs_list.txt
@@ -1,0 +1,2 @@
+disk1	10G	90G	10G	/mnt/disk1
+zmirror	20G	180G	20G	/mnt/zmirror

--- a/tests/fixtures/zfs_array/zpool_iostat_disk1.txt
+++ b/tests/fixtures/zfs_array/zpool_iostat_disk1.txt
@@ -1,0 +1,5 @@
+                                         capacity     operations     bandwidth
+pool                                   alloc   free   read  write   read  write
+-------------------------------------  -----  -----  -----  -----  -----  -----
+disk1                                  10G    90G    1      2      10M    20M
+  /dev/mapper/md1p1                    10G    90G    1      2      10M    20M

--- a/tests/fixtures/zfs_array/zpool_iostat_path_disk1.txt
+++ b/tests/fixtures/zfs_array/zpool_iostat_path_disk1.txt
@@ -1,0 +1,5 @@
+                                         capacity     operations     bandwidth
+pool                                   alloc   free   read  write   read  write
+-------------------------------------  -----  -----  -----  -----  -----  -----
+disk1                                  10G    90G    1      2      10M    20M
+  /dev/mapper/md1p1                    10G    90G    1      2      10M    20M

--- a/tests/fixtures/zfs_array/zpool_iostat_path_zmirror.txt
+++ b/tests/fixtures/zfs_array/zpool_iostat_path_zmirror.txt
@@ -1,0 +1,7 @@
+                                         capacity     operations     bandwidth
+pool                                   alloc   free   read  write   read  write
+-------------------------------------  -----  -----  -----  -----  -----  -----
+zmirror                                20G    180G   1      2      10M    20M
+  mirror-0                             20G    180G   1      2      10M    20M
+    /dev/nvme1n1p1                     10G    90G    1      2      5M     10M
+    /dev/nvme2n1p1                     10G    90G    1      2      5M     10M

--- a/tests/fixtures/zfs_array/zpool_iostat_zmirror.txt
+++ b/tests/fixtures/zfs_array/zpool_iostat_zmirror.txt
@@ -1,0 +1,7 @@
+                                         capacity     operations     bandwidth
+pool                                   alloc   free   read  write   read  write
+-------------------------------------  -----  -----  -----  -----  -----  -----
+zmirror                                20G    180G   1      2      10M    20M
+  mirror-0                             20G    180G   1      2      10M    20M
+    nvme1n1p1                          10G    90G    1      2      5M     10M
+    nvme2n1p1                          10G    90G    1      2      5M     10M

--- a/tests/fixtures/zfs_array/zpool_list.txt
+++ b/tests/fixtures/zfs_array/zpool_list.txt
@@ -1,0 +1,2 @@
+disk1	100G	10G	90G	-	-	10%	10%	1.00x	ONLINE	-
+zmirror	200G	20G	180G	-	-	10%	10%	1.00x	ONLINE	-

--- a/tests/fixtures/zfs_array/zpool_status_disk1.txt
+++ b/tests/fixtures/zfs_array/zpool_status_disk1.txt
@@ -1,0 +1,9 @@
+  pool: disk1
+ state: ONLINE
+config:
+
+	NAME                 STATE     READ WRITE CKSUM
+	disk1                ONLINE       0     0     0
+	  /dev/mapper/md1p1  ONLINE       0     0     0
+
+errors: No known data errors

--- a/tests/fixtures/zfs_array/zpool_status_path_disk1.txt
+++ b/tests/fixtures/zfs_array/zpool_status_path_disk1.txt
@@ -1,0 +1,9 @@
+  pool: disk1
+ state: ONLINE
+config:
+
+	NAME                 STATE     READ WRITE CKSUM
+	disk1                ONLINE       0     0     0
+	  /dev/mapper/md1p1  ONLINE       0     0     0
+
+errors: No known data errors

--- a/tests/fixtures/zfs_array/zpool_status_path_zmirror.txt
+++ b/tests/fixtures/zfs_array/zpool_status_path_zmirror.txt
@@ -1,0 +1,11 @@
+  pool: zmirror
+ state: ONLINE
+config:
+
+	NAME                STATE     READ WRITE CKSUM
+	zmirror             ONLINE       0     0     0
+	  mirror-0          ONLINE       0     0     0
+	    /dev/nvme1n1p1  ONLINE       0     0     0
+	    /dev/nvme2n1p1  ONLINE       0     0     0
+
+errors: No known data errors

--- a/tests/fixtures/zfs_array/zpool_status_zmirror.txt
+++ b/tests/fixtures/zfs_array/zpool_status_zmirror.txt
@@ -1,0 +1,11 @@
+  pool: zmirror
+ state: ONLINE
+config:
+
+	NAME         STATE     READ WRITE CKSUM
+	zmirror      ONLINE       0     0     0
+	  mirror-0   ONLINE       0     0     0
+	    nvme1n1p1 ONLINE       0     0     0
+	    nvme2n1p1 ONLINE       0     0     0
+
+errors: No known data errors

--- a/tests/run.php
+++ b/tests/run.php
@@ -553,6 +553,18 @@ assert_true(isset($zfs_raw_info['zfs_disks']['1-2']), 'raw-device zfs_info maps 
 assert_true(!isset($zfs_raw_info['zfs_disks']['sda1']), 'raw-device zfs_info does not expose raw sda1 key');
 assert_true(empty($zfs_raw_info['warnings']), 'raw-device zfs_info suppresses alias warning when drivemap can resolve devices');
 
+putenv('DRIVEMAP_ZFS_FIXTURE_DIR=' . $fixtures . '/zfs_array');
+[$zfs_array_code, $zfs_array_body] = run_api_action($root, 'zfs_info');
+assert_equal($zfs_array_code, 0, 'zfs_info array-device endpoint exits successfully');
+$zfs_array_info = json_decode($zfs_array_body, true);
+assert_true(is_array($zfs_array_info), 'zfs_info array-device endpoint returns JSON');
+assert_true(isset($zfs_array_info['zfs_disks']['1-1']), 'array-device zfs_info maps md1p1 pool to disk1 bay');
+assert_equal($zfs_array_info['zfs_disks']['1-1']['zpool_name'] ?? '', 'disk1', 'array-device zfs_info reports disk1 pool on bay 1-1');
+assert_true(!isset($zfs_array_info['zfs_disks']['/dev/mapper/md1p1']), 'array-device zfs_info does not expose md mapper key');
+assert_true(!isset($zfs_array_info['zfs_disks']['nvme1n1p1']), 'array-device zfs_info ignores unmapped nvme pool members');
+assert_true(!isset($zfs_array_info['zfs_disks']['nvme2n1p1']), 'array-device zfs_info ignores second unmapped nvme pool member');
+assert_true(empty($zfs_array_info['warnings']), 'array-device zfs_info suppresses warning for non-slot zfs devices');
+
 require_once $root . '/php/zfs_info.php';
 $lookup_refresh_path = $ctx['out_dir'] . '/zfs_lookup_refresh.json';
 file_put_contents($lookup_refresh_path, json_encode([

--- a/tests/run.php
+++ b/tests/run.php
@@ -553,24 +553,34 @@ assert_true(isset($zfs_raw_info['zfs_disks']['1-2']), 'raw-device zfs_info maps 
 assert_true(!isset($zfs_raw_info['zfs_disks']['sda1']), 'raw-device zfs_info does not expose raw sda1 key');
 assert_true(empty($zfs_raw_info['warnings']), 'raw-device zfs_info suppresses alias warning when drivemap can resolve devices');
 
-$prev_fixture = getenv('DRIVEMAP_ZFS_FIXTURE_DIR');
+$original_zfs_fixture_dir = getenv('DRIVEMAP_ZFS_FIXTURE_DIR');
 putenv('DRIVEMAP_ZFS_FIXTURE_DIR=' . $fixtures . '/zfs_array');
-[$zfs_array_code, $zfs_array_body] = run_api_action($root, 'zfs_info');
-assert_equal($zfs_array_code, 0, 'zfs_info array-device endpoint exits successfully');
-$zfs_array_info = json_decode($zfs_array_body, true);
-assert_true(is_array($zfs_array_info), 'zfs_info array-device endpoint returns JSON');
-assert_true(isset($zfs_array_info['zfs_disks']['1-1']), 'array-device zfs_info maps md1p1 pool to disk1 bay');
-assert_equal($zfs_array_info['zfs_disks']['1-1']['zpool_name'] ?? '', 'disk1', 'array-device zfs_info reports disk1 pool on bay 1-1');
-assert_true(!isset($zfs_array_info['zfs_disks']['/dev/mapper/md1p1']), 'array-device zfs_info does not expose md mapper key');
-assert_true(!isset($zfs_array_info['zfs_disks']['nvme1n1p1']), 'array-device zfs_info ignores unmapped nvme pool members');
-assert_true(!isset($zfs_array_info['zfs_disks']['nvme2n1p1']), 'array-device zfs_info ignores second unmapped nvme pool member');
-assert_true(empty($zfs_array_info['warnings']), 'array-device zfs_info suppresses warning for non-slot zfs devices');
-if ($prev_fixture === false) {
-  putenv('DRIVEMAP_ZFS_FIXTURE_DIR');
-} else {
-  putenv('DRIVEMAP_ZFS_FIXTURE_DIR=' . $prev_fixture);
+try {
+  [$zfs_array_code, $zfs_array_body] = run_api_action($root, 'zfs_info');
+  assert_equal($zfs_array_code, 0, 'zfs_info array-device endpoint exits successfully');
+  $zfs_array_info = json_decode($zfs_array_body, true);
+  assert_true(is_array($zfs_array_info), 'zfs_info array-device endpoint returns JSON');
+  assert_true(isset($zfs_array_info['zfs_disks']['1-1']), 'array-device zfs_info maps md1p1 pool to disk1 bay');
+  assert_equal($zfs_array_info['zfs_disks']['1-1']['zpool_name'] ?? '', 'disk1', 'array-device zfs_info reports disk1 pool on bay 1-1');
+  assert_true(!isset($zfs_array_info['zfs_disks']['/dev/mapper/md1p1']), 'array-device zfs_info does not expose md mapper key');
+  assert_true(!isset($zfs_array_info['zfs_disks']['nvme1n1p1']), 'array-device zfs_info ignores unmapped nvme pool members');
+  assert_true(!isset($zfs_array_info['zfs_disks']['nvme2n1p1']), 'array-device zfs_info ignores second unmapped nvme pool member');
+  assert_true(empty($zfs_array_info['warnings']), 'array-device zfs_info suppresses warning for non-slot zfs devices');
+} finally {
+  if ($original_zfs_fixture_dir === false) {
+    putenv('DRIVEMAP_ZFS_FIXTURE_DIR');
+  } else {
+    putenv('DRIVEMAP_ZFS_FIXTURE_DIR=' . $original_zfs_fixture_dir);
+  }
 }
+
 require_once $root . '/php/zfs_info.php';
+$malformed_alerts = verify_zfs_device_format([
+  'tank' => "\ttank        ONLINE       0     0     0\n\t  mirror-0  ONLINE       0     0     0\n\t    bad-disk  ONLINE       0     0     0\n",
+], 'tank', []);
+assert_true(!empty($malformed_alerts), 'zfs device format warns for unresolved malformed members');
+assert_true(strpos(implode('', $malformed_alerts), 'bad-disk') !== false, 'zfs device format warning names malformed member');
+
 $lookup_refresh_path = $ctx['out_dir'] . '/zfs_lookup_refresh.json';
 file_put_contents($lookup_refresh_path, json_encode([
   'rows' => [[

--- a/tests/run.php
+++ b/tests/run.php
@@ -553,6 +553,7 @@ assert_true(isset($zfs_raw_info['zfs_disks']['1-2']), 'raw-device zfs_info maps 
 assert_true(!isset($zfs_raw_info['zfs_disks']['sda1']), 'raw-device zfs_info does not expose raw sda1 key');
 assert_true(empty($zfs_raw_info['warnings']), 'raw-device zfs_info suppresses alias warning when drivemap can resolve devices');
 
+$prev_fixture = getenv('DRIVEMAP_ZFS_FIXTURE_DIR');
 putenv('DRIVEMAP_ZFS_FIXTURE_DIR=' . $fixtures . '/zfs_array');
 [$zfs_array_code, $zfs_array_body] = run_api_action($root, 'zfs_info');
 assert_equal($zfs_array_code, 0, 'zfs_info array-device endpoint exits successfully');
@@ -564,7 +565,11 @@ assert_true(!isset($zfs_array_info['zfs_disks']['/dev/mapper/md1p1']), 'array-de
 assert_true(!isset($zfs_array_info['zfs_disks']['nvme1n1p1']), 'array-device zfs_info ignores unmapped nvme pool members');
 assert_true(!isset($zfs_array_info['zfs_disks']['nvme2n1p1']), 'array-device zfs_info ignores second unmapped nvme pool member');
 assert_true(empty($zfs_array_info['warnings']), 'array-device zfs_info suppresses warning for non-slot zfs devices');
-
+if ($prev_fixture === false) {
+  putenv('DRIVEMAP_ZFS_FIXTURE_DIR');
+} else {
+  putenv('DRIVEMAP_ZFS_FIXTURE_DIR=' . $prev_fixture);
+}
 require_once $root . '/php/zfs_info.php';
 $lookup_refresh_path = $ctx['out_dir'] . '/zfs_lookup_refresh.json';
 file_put_contents($lookup_refresh_path, json_encode([


### PR DESCRIPTION
Add animation for zfs array disk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZFS device detection so array-backed disks and common alternate device paths are recognized more reliably.
  * Reduced false warnings for supported boot, flash, and NVMe-style devices.
  * Cleaned up ZFS output so only properly named disks are shown, resulting in more accurate device lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->