### PR TITLE
feat(ui): storage-pool detail card for non-ZFS pool disks

### DIFF
--- a/assets/45d/45drives-disks/assets/index.bbceb330.js
+++ b/assets/45d/45drives-disks/assets/index.bbceb330.js
@@ -37168,6 +37168,142 @@ function _sfc_render$1(_ctx, _cache, $props, $setup, $data, $options) {
   ]);
 }
 var ZfsSection = /* @__PURE__ */ _export_sfc(_sfc_main$1, [["render", _sfc_render$1]]);
+const _sfc_main$storage = {
+  setup() {
+    const currentDisk = inject("currentDisk");
+    const diskInfo = inject("diskInfo");
+    const rows = computed(() => (diskInfo == null ? void 0 : diskInfo.rows) ? diskInfo.rows.flat() : []);
+    const selectedDisk = computed(() => rows.value.find((slot) => (slot == null ? void 0 : slot["bay-id"]) === currentDisk.value));
+    const poolName = computed(() => {
+      var _a;
+      return ((_a = selectedDisk.value) == null ? void 0 : _a["storage-label"]) || "N/A";
+    });
+    const hasPoolInfo = computed(() => {
+      var _a, _b;
+      return ((_a = selectedDisk.value) == null ? void 0 : _a["storage-role"]) === "pool" && !!((_b = selectedDisk.value) == null ? void 0 : _b["storage-label"]);
+    });
+    const poolMembers = computed(() => {
+      if (!hasPoolInfo.value)
+        return [];
+      return rows.value.filter((slot) => {
+        var _a, _b;
+        return (slot == null ? void 0 : slot["storage-role"]) === "pool" && (slot == null ? void 0 : slot["storage-label"]) === ((_b = (_a = selectedDisk.value) == null ? void 0 : _a["storage-label"]) != null ? _b : "");
+      });
+    });
+    const firstValue = (key) => {
+      var _a;
+      const match = poolMembers.value.find((slot) => slot == null ? void 0 : slot[key]);
+      return ((_a = match == null ? void 0 : match[key]) != null ? _a : "N/A");
+    };
+    const uniqueValues = (key) => Array.from(new Set(poolMembers.value.map((slot) => slot == null ? void 0 : slot[key]).filter(Boolean)));
+    const filesystem = computed(() => {
+      const values = uniqueValues("fs-type");
+      return values.length ? values.join(", ") : "N/A";
+    });
+    const status = computed(() => firstValue("fs-status"));
+    const mountpoint = computed(() => firstValue("fs-mountpoint"));
+    const slotSummary = computed(() => {
+      const values = poolMembers.value.map((slot) => slot == null ? void 0 : slot["bay-id"]).filter(Boolean);
+      return values.length ? values.join(", ") : "N/A";
+    });
+    const deviceSummary = computed(() => {
+      const values = poolMembers.value.map((slot) => (slot == null ? void 0 : slot.dev) || (slot == null ? void 0 : slot["dev-by-path"])).filter(Boolean);
+      return values.length ? values.join(", ") : "N/A";
+    });
+    return {
+      hasPoolInfo,
+      poolName,
+      poolMembers,
+      filesystem,
+      status,
+      mountpoint,
+      slotSummary,
+      deviceSummary
+    };
+  }
+};
+const _hoisted_storage_1 = {
+  id: "storageCard",
+  class: "card grow flex flex-col"
+};
+const _hoisted_storage_2 = /* @__PURE__ */ createBaseVNode("div", { class: "card-header" }, [
+  /* @__PURE__ */ createBaseVNode("h3", { class: "text-header text-default" }, "Pool Information")
+], -1);
+const _hoisted_storage_3 = {
+  key: 0,
+  class: "card-body overflow-y-auto grow-0 flex flex-wrap gap-12"
+};
+const _hoisted_storage_4 = { class: "grow-0 2xl:grow grid grid-cols-3 items-stretch gap-y-3 gap-x-5" };
+const _hoisted_storage_5 = /* @__PURE__ */ createBaseVNode("div", { class: "text-label text-default col-span-3 border-b-[1px] shrink-0 border-neutral-200 dark:border-neutral-700" }, " Pool ", -1);
+const _hoisted_storage_6 = /* @__PURE__ */ createBaseVNode("div", { class: "text-sm text-muted" }, "name", -1);
+const _hoisted_storage_7 = { class: "text-sm break-words" };
+const _hoisted_storage_8 = /* @__PURE__ */ createBaseVNode("div", { class: "text-sm text-muted" }, "filesystem", -1);
+const _hoisted_storage_9 = { class: "text-sm break-words" };
+const _hoisted_storage_10 = /* @__PURE__ */ createBaseVNode("div", { class: "text-sm text-muted" }, "status", -1);
+const _hoisted_storage_11 = { class: "text-sm break-words" };
+const _hoisted_storage_12 = /* @__PURE__ */ createBaseVNode("div", { class: "text-sm text-muted" }, "mountpoint", -1);
+const _hoisted_storage_13 = { class: "text-sm break-words" };
+const _hoisted_storage_14 = /* @__PURE__ */ createBaseVNode("div", { class: "text-sm text-muted" }, "members", -1);
+const _hoisted_storage_15 = { class: "text-sm break-words" };
+const _hoisted_storage_16 = { class: "grow-0 2xl:grow grid grid-cols-3 items-stretch gap-y-3 gap-x-5" };
+const _hoisted_storage_17 = /* @__PURE__ */ createBaseVNode("div", { class: "text-label text-default col-span-3 border-b-[1px] shrink-0 border-neutral-200 dark:border-neutral-700" }, " Devices ", -1);
+const _hoisted_storage_18 = /* @__PURE__ */ createBaseVNode("div", { class: "text-sm text-muted" }, "slots", -1);
+const _hoisted_storage_19 = { class: "text-sm break-words" };
+const _hoisted_storage_20 = { class: "col-span-2" };
+const _hoisted_storage_21 = /* @__PURE__ */ createBaseVNode("div", { class: "text-sm text-muted" }, "devices", -1);
+const _hoisted_storage_22 = { class: "text-sm break-words" };
+const _hoisted_storage_23 = {
+  key: 1,
+  class: "card-body grow flex justify-center items-center"
+};
+const _hoisted_storage_24 = /* @__PURE__ */ createBaseVNode("div", { class: "p-5 bg-accent rounded-lg" }, [
+  /* @__PURE__ */ createBaseVNode("span", { class: "text-muted" }, "Click on a pool disk for more detail.")
+], -1);
+const _hoisted_storage_25 = [
+  _hoisted_storage_24
+];
+function _sfc_render$storage(_ctx, _cache, $props, $setup, $data, $options) {
+  return openBlock(), createElementBlock("div", _hoisted_storage_1, [
+    _hoisted_storage_2,
+    $setup.hasPoolInfo ? (openBlock(), createElementBlock("div", _hoisted_storage_3, [
+      createBaseVNode("div", _hoisted_storage_4, [
+        _hoisted_storage_5,
+        createBaseVNode("div", null, [
+          _hoisted_storage_6,
+          createBaseVNode("div", _hoisted_storage_7, toDisplayString($setup.poolName), 1)
+        ]),
+        createBaseVNode("div", null, [
+          _hoisted_storage_8,
+          createBaseVNode("div", _hoisted_storage_9, toDisplayString($setup.filesystem), 1)
+        ]),
+        createBaseVNode("div", null, [
+          _hoisted_storage_10,
+          createBaseVNode("div", _hoisted_storage_11, toDisplayString($setup.status), 1)
+        ]),
+        createBaseVNode("div", null, [
+          _hoisted_storage_12,
+          createBaseVNode("div", _hoisted_storage_13, toDisplayString($setup.mountpoint), 1)
+        ]),
+        createBaseVNode("div", null, [
+          _hoisted_storage_14,
+          createBaseVNode("div", _hoisted_storage_15, toDisplayString($setup.poolMembers.length), 1)
+        ])
+      ]),
+      createBaseVNode("div", _hoisted_storage_16, [
+        _hoisted_storage_17,
+        createBaseVNode("div", null, [
+          _hoisted_storage_18,
+          createBaseVNode("div", _hoisted_storage_19, toDisplayString($setup.slotSummary), 1)
+        ]),
+        createBaseVNode("div", _hoisted_storage_20, [
+          _hoisted_storage_21,
+          createBaseVNode("div", _hoisted_storage_22, toDisplayString($setup.deviceSummary), 1)
+        ])
+      ])
+    ])) : (openBlock(), createElementBlock("div", _hoisted_storage_23, _hoisted_storage_25))
+  ]);
+}
+var StorageSection = /* @__PURE__ */ _export_sfc(_sfc_main$storage, [["render", _sfc_render$storage]]);
 var App_vue_vue_type_style_index_0_lang = "";
 const _sfc_main = {
   name: "App",
@@ -37179,6 +37315,7 @@ const _sfc_main = {
     CanvasSection,
     ErrorMessage,
     ZfsSection,
+    StorageSection,
     Notifications
   },
   props: { notificationFIFO: FIFO },
@@ -37203,9 +37340,20 @@ const _sfc_main = {
       }
       return Object.prototype.hasOwnProperty.call(zfsInfo.zfs_disks, currentDisk.value);
     });
+    const selectedDiskHasStoragePool = computed(() => {
+      if (!currentDisk.value || !diskInfo.rows) {
+        return false;
+      }
+      const slot = diskInfo.rows.flat().find((disk) => (disk == null ? void 0 : disk["bay-id"]) === currentDisk.value);
+      return (slot == null ? void 0 : slot["storage-role"]) === "pool" && !!(slot == null ? void 0 : slot["storage-label"]) && !selectedDiskHasZfs.value;
+    });
+    const selectedDiskHasDetailCard = computed(() => selectedDiskHasZfs.value || selectedDiskHasStoragePool.value);
     const activePageLayout = computed(() => {
-      if (selectedDiskHasZfs.value) {
+      if (selectedDiskHasDetailCard.value && pageLayout.value.includes("Z")) {
         return pageLayout.value;
+      }
+      if (selectedDiskHasDetailCard.value) {
+        return `${pageLayout.value.replace("Z", "")}Z`;
       }
       return pageLayout.value.replace("Z", "");
     });
@@ -37613,6 +37761,8 @@ const _sfc_main = {
       pageLayout,
       activePageLayout,
       selectedDiskHasZfs,
+      selectedDiskHasStoragePool,
+      selectedDiskHasDetailCard,
       notifications
     };
   }
@@ -37659,6 +37809,7 @@ function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   const _component_CanvasSection = resolveComponent("CanvasSection");
   const _component_DiskSection = resolveComponent("DiskSection");
   const _component_ZfsSection = resolveComponent("ZfsSection");
+  const _component_StorageSection = resolveComponent("StorageSection");
   const _component_ServerSection = resolveComponent("ServerSection");
   return openBlock(), createElementBlock(Fragment, null, [
     createVNode(_component_Notifications, {
@@ -37704,7 +37855,7 @@ function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
           }, [
             $setup.preloadChecks.serverInfo.finished && $setup.preloadChecks.diskInfo.finished && !$setup.preloadChecks.serverInfo.failed && !$setup.preloadChecks.diskInfo.failed && $setup.preloadChecks.pageStatus.ready ? (openBlock(), createBlock(_component_DiskSection, { key: 0 })) : createCommentVNode("", true)
           ], 2)) : createCommentVNode("", true),
-          $setup.preloadChecks.zfs.finished && !$setup.preloadChecks.zfs.failed && !$setup.preloadChecks.serverInfo.failed && !$setup.preloadChecks.diskInfo.failed && $setup.selectedDiskHasZfs && $setup.preloadChecks.pageStatus.ready ? (openBlock(), createElementBlock("div", {
+          $setup.preloadChecks.zfs.finished && !$setup.preloadChecks.serverInfo.failed && !$setup.preloadChecks.diskInfo.failed && $setup.selectedDiskHasDetailCard && $setup.preloadChecks.pageStatus.ready ? (openBlock(), createElementBlock("div", {
             key: 1,
             class: normalizeClass([
               $setup.activePageLayout === "AZ" ? "lg:col-span-3" : "",
@@ -37713,7 +37864,7 @@ function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
               "grow grid gap-well col-span-6"
             ])
           }, [
-            $setup.preloadChecks.zfs.finished && !$setup.preloadChecks.zfs.failed ? (openBlock(), createBlock(_component_ZfsSection, { key: 0 })) : createCommentVNode("", true)
+            $setup.selectedDiskHasZfs && $setup.preloadChecks.zfs.finished && !$setup.preloadChecks.zfs.failed ? (openBlock(), createBlock(_component_ZfsSection, { key: 0 })) : $setup.selectedDiskHasStoragePool ? (openBlock(), createBlock(_component_StorageSection, { key: 1 })) : createCommentVNode("", true)
           ], 2)) : createCommentVNode("", true),
           createBaseVNode("div", _hoisted_5, [
             $setup.preloadChecks.serverInfo.finished && $setup.preloadChecks.lsdev.finished ? (openBlock(), createBlock(_component_ServerSection, {

--- a/assets/45d/drivemap.js
+++ b/assets/45d/drivemap.js
@@ -91,6 +91,21 @@
     if (bay.health) {
       parts.push('Health ' + bay.health);
     }
+    if (bay['storage-role']) {
+      parts.push('Role ' + bay['storage-role']);
+    }
+    if (bay['storage-label']) {
+      parts.push('Pool ' + bay['storage-label']);
+    }
+    if (bay['fs-type']) {
+      parts.push('FS ' + bay['fs-type']);
+    }
+    if (bay['fs-status']) {
+      parts.push('Status ' + bay['fs-status']);
+    }
+    if (bay['fs-mountpoint']) {
+      parts.push('Mount ' + bay['fs-mountpoint']);
+    }
 
     return parts.join(' | ');
   }

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/App.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/App.vue
@@ -15,6 +15,7 @@ import {
   FIFO,
 } from "@45drives/cockpit-helpers";
 import ZfsSection from "./components/ZfsSection.vue";
+import StorageSection from "./components/StorageSection.vue";
 import Notifications from "./components/Notifications.vue";
 
 export default {
@@ -27,6 +28,7 @@ export default {
     CanvasSection,
     ErrorMessage,
     ZfsSection,
+    StorageSection,
     Notifications,
   },
   props: { notificationFIFO: FIFO },
@@ -55,9 +57,31 @@ export default {
         currentDisk.value
       );
     });
+    const selectedDiskHasStoragePool = computed(() => {
+      if (!currentDisk.value || !diskInfo.rows) {
+        return false;
+      }
+
+      const slot = diskInfo.rows
+        .flat()
+        .find((disk) => disk?.["bay-id"] === currentDisk.value);
+
+      return (
+        slot?.["storage-role"] === "pool" &&
+        !!slot?.["storage-label"] &&
+        !selectedDiskHasZfs.value
+      );
+    });
+    const selectedDiskHasDetailCard = computed(
+      () => selectedDiskHasZfs.value || selectedDiskHasStoragePool.value
+    );
     const activePageLayout = computed(() => {
-      if (selectedDiskHasZfs.value) {
+      if (selectedDiskHasDetailCard.value && pageLayout.value.includes("Z")) {
         return pageLayout.value;
+      }
+
+      if (selectedDiskHasDetailCard.value) {
+        return `${pageLayout.value.replace("Z", "")}Z`;
       }
 
       return pageLayout.value.replace("Z", "");
@@ -586,6 +610,8 @@ export default {
       pageLayout,
       activePageLayout,
       selectedDiskHasZfs,
+      selectedDiskHasStoragePool,
+      selectedDiskHasDetailCard,
       notifications,
     };
   },
@@ -669,10 +695,9 @@ export default {
         <div
           v-if="
             preloadChecks.zfs.finished &&
-            !preloadChecks.zfs.failed &&
             !preloadChecks.serverInfo.failed &&
             !preloadChecks.diskInfo.failed &&
-            selectedDiskHasZfs &&
+            selectedDiskHasDetailCard &&
             preloadChecks.pageStatus.ready
           "
           :class="[
@@ -683,8 +708,9 @@ export default {
           ]"
         >
           <ZfsSection
-            v-if="preloadChecks.zfs.finished && !preloadChecks.zfs.failed"
+            v-if="selectedDiskHasZfs && preloadChecks.zfs.finished && !preloadChecks.zfs.failed"
           />
+          <StorageSection v-else-if="selectedDiskHasStoragePool" />
         </div>
 
         <div class="flex grow flex-col items-stretch gap-well col-span-6">

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/StorageSection.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/StorageSection.vue
@@ -1,0 +1,129 @@
+<template>
+  <div id="storageCard" class="card grow flex flex-col">
+    <div class="card-header">
+      <h3 class="text-header text-default">Pool Information</h3>
+    </div>
+    <div
+      v-if="hasPoolInfo"
+      class="card-body overflow-y-auto grow-0 flex flex-wrap gap-12"
+    >
+      <div
+        class="grow-0 2xl:grow grid grid-cols-3 items-stretch gap-y-3 gap-x-5"
+      >
+        <div
+          class="text-label text-default col-span-3 border-b-[1px] shrink-0 border-neutral-200 dark:border-neutral-700"
+        >
+          Pool
+        </div>
+        <div class="grid grid-cols-1">
+          <div class="text-sm text-muted">name</div>
+          <div class="text-sm break-words">{{ poolName }}</div>
+        </div>
+        <div class="grid grid-cols-1">
+          <div class="text-sm text-muted">filesystem</div>
+          <div class="text-sm break-words">{{ filesystem }}</div>
+        </div>
+        <div class="grid grid-cols-1">
+          <div class="text-sm text-muted">status</div>
+          <div class="text-sm break-words">{{ status }}</div>
+        </div>
+        <div class="grid grid-cols-1">
+          <div class="text-sm text-muted">mountpoint</div>
+          <div class="text-sm break-words">{{ mountpoint }}</div>
+        </div>
+        <div class="grid grid-cols-1">
+          <div class="text-sm text-muted">members</div>
+          <div class="text-sm break-words">{{ poolMembers.length }}</div>
+        </div>
+      </div>
+
+      <div
+        class="grow-0 2xl:grow grid grid-cols-3 items-stretch gap-y-3 gap-x-5"
+      >
+        <div
+          class="text-label text-default col-span-3 border-b-[1px] shrink-0 border-neutral-200 dark:border-neutral-700"
+        >
+          Devices
+        </div>
+        <div>
+          <div class="text-sm text-muted">slots</div>
+          <div class="text-sm break-words">{{ slotSummary }}</div>
+        </div>
+        <div class="col-span-2">
+          <div class="text-sm text-muted">devices</div>
+          <div class="text-sm break-words">{{ deviceSummary }}</div>
+        </div>
+      </div>
+    </div>
+    <div v-else class="card-body grow flex justify-center items-center">
+      <div class="p-5 bg-accent rounded-lg">
+        <span class="text-muted">Click on a pool disk for more detail.</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { computed, inject } from "vue";
+
+export default {
+  setup() {
+    const currentDisk = inject("currentDisk");
+    const diskInfo = inject("diskInfo");
+
+    const rows = computed(() => (diskInfo?.rows ? diskInfo.rows.flat() : []));
+    const selectedDisk = computed(() =>
+      rows.value.find((slot) => slot?.["bay-id"] === currentDisk.value)
+    );
+    const poolName = computed(() => selectedDisk.value?.["storage-label"] || "N/A");
+    const hasPoolInfo = computed(
+      () =>
+        selectedDisk.value?.["storage-role"] === "pool" &&
+        !!selectedDisk.value?.["storage-label"]
+    );
+    const poolMembers = computed(() => {
+      if (!hasPoolInfo.value) return [];
+      return rows.value.filter(
+        (slot) =>
+          slot?.["storage-role"] === "pool" &&
+          slot?.["storage-label"] === selectedDisk.value["storage-label"]
+      );
+    });
+    const firstValue = (key) => {
+      const match = poolMembers.value.find((slot) => slot?.[key]);
+      return match?.[key] || "N/A";
+    };
+    const uniqueValues = (key) =>
+      Array.from(
+        new Set(poolMembers.value.map((slot) => slot?.[key]).filter(Boolean))
+      );
+    const filesystem = computed(() => {
+      const values = uniqueValues("fs-type");
+      return values.length ? values.join(", ") : "N/A";
+    });
+    const status = computed(() => firstValue("fs-status"));
+    const mountpoint = computed(() => firstValue("fs-mountpoint"));
+    const slotSummary = computed(() => {
+      const values = poolMembers.value.map((slot) => slot?.["bay-id"]).filter(Boolean);
+      return values.length ? values.join(", ") : "N/A";
+    });
+    const deviceSummary = computed(() => {
+      const values = poolMembers.value
+        .map((slot) => slot?.dev || slot?.["dev-by-path"])
+        .filter(Boolean);
+      return values.length ? values.join(", ") : "N/A";
+    });
+
+    return {
+      hasPoolInfo,
+      poolName,
+      poolMembers,
+      filesystem,
+      status,
+      mountpoint,
+      slotSummary,
+      deviceSummary,
+    };
+  },
+};
+</script>


### PR DESCRIPTION
## What
Adds an Unraid **storage-pool detail card** that appears when a selected drive bay is a pool member but is **not** a ZFS device.

- New `StorageSection.vue` component rendering the pool's storage details.
- `App.vue`: adds `selectedDiskHasStoragePool` / `selectedDiskHasDetailCard` computeds and shows the card in the detail slot (`ZfsSection` for ZFS, `StorageSection` for non-ZFS pool members).
- `drivemap.js`: bay tooltip now surfaces `storage-role`, `storage-label`, `fs-type`, `fs-status`, `fs-mountpoint`.
- Rebuilt deployed bundle (`index.bbceb330.js`) reflecting the above.

## Base / merge notes
This work originated on the now-merged `codex/zfs-raw-device-bay-map` branch (PR #2), which predated `main`'s drive-standby work (PR #5). It was cherry-picked onto current `main` so the compiled bundle retains **both** the standby/power-mode features and the new storage-pool card. Diff vs `main` is purely additive.

## Test
- Verified merged bundle contains both feature sets (standby/power-mode + storage-pool).
- Tooltip renders Power, Role, Pool, FS and Mount lines together.