### PR TITLE
fix(ui): make module header title non-clickable (stop iframe nesting)

### DIFF
--- a/assets/45d/45drives-disks/assets/index.bbceb330.js
+++ b/assets/45d/45drives-disks/assets/index.bbceb330.js
@@ -5011,9 +5011,6 @@ const _sfc_main$A = {
     } else {
       document.documentElement.classList.remove("dark");
     }
-    const home = () => {
-      cockpit.location.go("/");
-    };
     watch(() => darkMode.value, (darkMode2, oldDarkMode) => {
       localStorage.setItem("color-theme", darkMode2 ? "dark" : "light");
       if (darkMode2) {
@@ -5023,8 +5020,7 @@ const _sfc_main$A = {
       }
     }, { lazy: false });
     return {
-      darkMode,
-      home
+      darkMode
     };
   },
   components: {
@@ -5056,8 +5052,7 @@ function _sfc_render$A(_ctx, _cache, $props, $setup, $data, $options) {
       ])
     ]),
     createBaseVNode("h1", {
-      class: "text-red-800 dark:text-white text-2xl cursor-pointer grow-0 text-center",
-      onClick: _cache[0] || (_cache[0] = (...args) => $setup.home && $setup.home(...args))
+      class: "text-red-800 dark:text-white text-2xl grow-0 text-center"
     }, toDisplayString($props.moduleName), 1),
     createBaseVNode("div", _hoisted_6$8, [
       createBaseVNode("button", {

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/FfdHeader.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/FfdHeader.vue
@@ -28,8 +28,7 @@ If not, see <https://www.gnu.org/licenses/>.
 			</h1>
 		</div>
 		<h1
-			class="text-red-800 dark:text-white text-2xl cursor-pointer grow-0 text-center"
-			@click="home"
+			class="text-red-800 dark:text-white text-2xl grow-0 text-center"
 		>{{ moduleName }}</h1>
 		<div class="flex basis-32 justify-end grow shrink-0">
 			<button
@@ -74,9 +73,6 @@ export default {
 		} else {
 			document.documentElement.classList.remove("dark");
 		}
-		const home = () => {
-			cockpit.location.go('/');
-		};
 		watch(() => darkMode.value, (darkMode, oldDarkMode) => {
 			localStorage.setItem("color-theme", darkMode ? "dark" : "light");
 			if (darkMode) {
@@ -87,7 +83,6 @@ export default {
 		}, { lazy: false });
 		return {
 			darkMode,
-			home,
 		};
 	},
 	components: {


### PR DESCRIPTION
## Problem
The module header title (`FfdHeader.vue`) had `@click="home"` → `cockpit.location.go('/')`. In the Unraid/Cockpit context this navigates the plugin's iframe to the site root, which reloads the entire UI **inside** the iframe — nesting a sub-iframe ("iframe explodes into a sub-iframe").

## Fix
Make the title plain, non-interactive text:
- Remove the `@click="home"` handler and the `cursor-pointer` affordance from the `<h1>`.
- Remove the now-unused `home()` helper and its `setup()` export.
- Mirror the change in the deployed bundle (`index.bbceb330.js`), per the repo's source+bundle convention.

## Verification
- No remaining `$setup.home` / `cockpit.location.go` references in the bundle.
- `node --check` passes on the bundle.

Independent of the storage-pool-card PR; branched off `main`.