### PR TITLE
feat(ui): port drive-standby / power-mode work into Vue source

### DIFF
--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/DiskSection.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/DiskSection.vue
@@ -162,6 +162,13 @@
 						<span v-else>N/A</span>
 					</div>
 				</div>
+				<div class="grid grid-cols-1 self-start py-1 md:py-2 px-2">
+					<div class="text-sm text-muted">Power Mode</div>
+					<div class="text-sm break-words">
+						<span v-if="diskObj['power-mode']">{{ diskObj['power-mode'] }}</span>
+						<span v-else>N/A</span>
+					</div>
+				</div>
 				<div
 					v-if="hasStorageDetails"
 					class="text-label text-default col-span-2 2xl:col-span-3 border-b-[1px] shrink-0 border-neutral-200 dark:border-neutral-700 mx-2 pt-2"

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5F8X1.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5F8X1.vue
@@ -291,6 +291,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -313,6 +314,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -401,6 +403,7 @@ export default {
                     );
                     if (index === -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -438,6 +441,11 @@ export default {
                 diskLocations.forEach((loc) => {
                     if (loc.occupied && loc.image) {
                         p5.image(loc.image, loc.x, loc.y);
+                        if (loc.standby) {
+                          p5.noStroke();
+                          p5.fill(255, 165, 0, 80);
+                          p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5F8X2.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5F8X2.vue
@@ -451,6 +451,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -473,6 +474,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -561,6 +563,7 @@ export default {
                     );
                     if (index === -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -598,6 +601,11 @@ export default {
                 diskLocations.forEach((loc) => {
                     if (loc.occupied && loc.image) {
                         p5.image(loc.image, loc.x, loc.y);
+                        if (loc.standby) {
+                          p5.noStroke();
+                          p5.fill(255, 165, 0, 80);
+                          p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5F8X3.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5F8X3.vue
@@ -613,6 +613,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -635,6 +636,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -723,6 +725,7 @@ export default {
                     );
                     if (index === -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -760,6 +763,11 @@ export default {
                 diskLocations.forEach((loc) => {
                     if (loc.occupied && loc.image) {
                         p5.image(loc.image, loc.x, loc.y);
+                        if (loc.standby) {
+                          p5.noStroke();
+                          p5.fill(255, 165, 0, 80);
+                          p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL15.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL15.vue
@@ -235,6 +235,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -257,6 +258,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -332,6 +334,7 @@
             );
             if (index === -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -369,6 +372,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL15BEAST.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL15BEAST.vue
@@ -139,6 +139,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -161,6 +162,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -276,6 +278,7 @@
             );
             if (index === -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -310,6 +313,11 @@
               const w = loc.image.width * 1.11;
               const h = loc.image.height * 1.11;
               p5.image(loc.image, loc.x, loc.y, w, h);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, w, h - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL4.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL4.vue
@@ -122,6 +122,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -144,6 +145,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -220,6 +222,7 @@
             );
             if (index === -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -259,6 +262,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL8.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL8.vue
@@ -125,6 +125,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -147,6 +148,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -222,6 +224,7 @@
             );
             if (index === -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -261,6 +264,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProfessionalPRO15.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProfessionalPRO15.vue
@@ -235,6 +235,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -257,6 +258,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -332,6 +334,7 @@
             );
             if (index === -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -369,6 +372,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProfessionalPRO4.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProfessionalPRO4.vue
@@ -122,6 +122,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -144,6 +145,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -220,6 +222,7 @@
             );
             if (index === -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -259,6 +262,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProfessionalPRO8.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProfessionalPRO8.vue
@@ -125,6 +125,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -147,6 +148,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -222,6 +224,7 @@
             );
             if (index === -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -261,6 +264,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM16.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM16.vue
@@ -122,6 +122,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -145,6 +146,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -240,6 +242,7 @@ export default {
                         (loc) => loc.BAY === slot["bay-id"]
                     );
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -273,6 +276,11 @@ export default {
                 diskLocations.forEach((loc) => {
                     if (loc.occupied && loc.image) {
                         p5.image(loc.image, loc.x, loc.y);
+                        if (loc.standby) {
+                          p5.noStroke();
+                          p5.fill(255, 165, 0, 80);
+                          p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM2.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM2.vue
@@ -104,6 +104,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -127,6 +128,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -222,6 +224,7 @@ export default {
                         (loc) => loc.BAY === slot["bay-id"]
                     );
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -255,6 +258,11 @@ export default {
                 diskLocations.forEach((loc) => {
                     if (loc.occupied && loc.image) {
                         p5.image(loc.image, loc.x, loc.y, DRAWN_WIDTH, DRAWN_HEIGHT);
+                        if (loc.standby) {
+                            p5.noStroke();
+                            p5.fill(255, 165, 0, 80);
+                            p5.rect(loc.x, loc.y, DRAWN_WIDTH, DRAWN_HEIGHT - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM32.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM32.vue
@@ -361,6 +361,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -384,6 +385,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -479,6 +481,7 @@ export default {
                         (loc) => loc.BAY === slot["bay-id"]
                     );
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -512,6 +515,11 @@ export default {
                 diskLocations.forEach((loc) => {
                     if (loc.occupied && loc.image) {
                         p5.image(loc.image, loc.x, loc.y);
+                        if (loc.standby) {
+                          p5.noStroke();
+                          p5.fill(255, 165, 0, 80);
+                          p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM8.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM8.vue
@@ -182,6 +182,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -205,6 +206,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -300,6 +302,7 @@ export default {
                         (loc) => loc.BAY === slot["bay-id"]
                     );
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -333,6 +336,11 @@ export default {
                 diskLocations.forEach((loc) => {
                     if (loc.occupied && loc.image) {
                         p5.image(loc.image, loc.x, loc.y);
+                        if (loc.standby) {
+                          p5.noStroke();
+                          p5.fill(255, 165, 0, 80);
+                          p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorAV15.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorAV15.vue
@@ -235,6 +235,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -257,6 +258,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -332,6 +334,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -369,6 +372,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorC8.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorC8.vue
@@ -113,6 +113,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(slot.occupied);
         });
       },
@@ -130,6 +131,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(slot.occupied);
         });
       },
@@ -163,6 +165,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(slot.occupied);
         });
       };
@@ -189,6 +192,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorMI4.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorMI4.vue
@@ -86,6 +86,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(slot.occupied);
         });
       },
@@ -102,6 +103,7 @@ export default {
               (loc) => loc.BAY === slot["bay-id"]
             );
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(slot.occupied);
           });
         }
@@ -136,6 +138,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(slot.occupied);
         });
       };
@@ -162,6 +165,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorQ30.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorQ30.vue
@@ -400,6 +400,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -422,6 +423,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -458,6 +460,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -496,6 +499,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorQ30H16.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorQ30H16.vue
@@ -438,6 +438,7 @@ export default {
           );
           if(index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -461,6 +462,7 @@ export default {
           );
           if(index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -549,6 +551,7 @@ zfsAnimation(p5);
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -586,6 +589,11 @@ zfsAnimation(p5);
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorQ30H32.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorQ30H32.vue
@@ -509,6 +509,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -531,6 +532,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -621,6 +623,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -658,6 +661,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorS45.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorS45.vue
@@ -490,6 +490,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -512,6 +513,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -596,6 +598,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -633,6 +636,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorS45H16.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorS45H16.vue
@@ -557,6 +557,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -580,6 +581,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -670,6 +672,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -707,6 +710,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorS45H32.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorS45H32.vue
@@ -628,6 +628,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -650,6 +651,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -740,6 +742,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -777,6 +780,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorXL60.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorXL60.vue
@@ -608,6 +608,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -630,6 +631,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -714,6 +716,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -751,6 +754,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorXL60H16.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorXL60H16.vue
@@ -681,6 +681,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -703,6 +704,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -793,6 +795,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -835,6 +838,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorXL60H32.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorXL60H32.vue
@@ -749,6 +749,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -771,6 +772,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -861,6 +863,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -898,6 +901,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5Stornado.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5Stornado.vue
@@ -410,6 +410,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -432,6 +433,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -466,6 +468,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -503,6 +506,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5Stornado2U.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5Stornado2U.vue
@@ -353,6 +353,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -376,6 +377,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -465,6 +467,7 @@ export default {
             (loc) => loc.BAY === slot["bay-id"]
           );
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -498,6 +501,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StornadoF16.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StornadoF16.vue
@@ -235,6 +235,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -258,6 +259,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -353,6 +355,7 @@
               (loc) => loc.BAY === slot["bay-id"]
             );
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -386,6 +389,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y,DRAWN_WIDTH,DRAWN_HEIGHT);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, DRAWN_WIDTH, DRAWN_HEIGHT - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StornadoF2.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StornadoF2.vue
@@ -361,6 +361,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -384,6 +385,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -479,6 +481,7 @@
               (loc) => loc.BAY === slot["bay-id"]
             );
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -512,6 +515,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StudioSTUDIO8.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StudioSTUDIO8.vue
@@ -62,6 +62,7 @@ export default {
                     const index = diskLocations.findIndex((loc) => loc.BAY === slot["bay-id"]);
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -82,6 +83,7 @@ export default {
                     const index = diskLocations.findIndex((loc) => loc.BAY === slot["bay-id"]);
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -124,6 +126,7 @@ export default {
                     const index = diskLocations.findIndex((loc) => loc.BAY === slot["bay-id"]);
                     if (index === -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -159,6 +162,11 @@ export default {
                         const w = loc.image.width * 2.1;
                         const h = loc.image.height * 2.49;
                         p5.image(loc.image, loc.x, loc.y, w, h);
+                        if (loc.standby) {
+                            p5.noStroke();
+                            p5.fill(255, 165, 0, 80);
+                            p5.rect(loc.x, loc.y, w, h - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/ServerSection.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/ServerSection.vue
@@ -194,24 +194,15 @@ export default {
 
     const updateDiskSummary = () => {
       if (lsdevJson.rows) {
-        diskCount.value = lsdevJson.rows
+        const occupiedDisks = lsdevJson.rows
           .flat()
-          .filter((slot) => slot.occupied).length;
+          .filter((slot) => slot.occupied);
 
-        // storageCapacity.value =
-        //   diskCount.value > 0
-        //     ? lsdevJson.rows
-        //         .flat()
-        //         .filter((slot) => slot.occupied)
-        //         .map((disk) => getCapacityGiB(disk.capacity))
-        //         .reduce((total, cap) => total + cap)
-        //         .toFixed(2)
-        //     : 0;
+        diskCount.value = occupiedDisks.length;
+
         storageCapacity.value =
           diskCount.value > 0
-            ? lsdevJson.rows
-              .flat()
-              .filter((slot) => slot.occupied)
+            ? occupiedDisks
               .map((disk) => getCapacityGiB(disk.capacity))
               .reduce((total, cap) => total + cap)
             : 0;
@@ -221,23 +212,25 @@ export default {
             ? (storageCapacity.value / 1000).toFixed(2).toString() + " TB"
             : storageCapacity.value.toString() + " GB";
 
+        // Spun-down drives report no temperature; exclude them so the average
+        // reflects only the drives that are actually spun up.
+        const tempReadings = occupiedDisks
+          .map((disk) => Number(disk["temp-c"]?.replace(/[^0-9]/g, "") ?? 0))
+          .filter((temp) => temp > 0);
+
         avgTemp.value =
-          diskCount.value > 0
+          tempReadings.length > 0
             ? (
-                lsdevJson.rows
-                  .flat()
-                  .filter((slot) => slot.occupied)
-                  .map((disk) =>
-                    Number(disk["temp-c"]?.replace(/[^0-9]/g, "") ?? 0)
-                  )
-                  .reduce((total, cap) => total + cap) / Number(diskCount.value)
+                tempReadings.reduce((total, cap) => total + cap) /
+                Number(tempReadings.length)
               ).toFixed(2)
             : 0;
-        
-        if(avgTemp.value === 0){
-          avgTempStr.value = "No Disks Present";
-        }
 
+        if (diskCount.value === 0) {
+          avgTempStr.value = "No Disks Present";
+        } else if (tempReadings.length === 0) {
+          avgTempStr.value = "All drives are spundown";
+        }
       }
     };
 


### PR DESCRIPTION
## Why
The drive-standby feature (commit `024a867`, "Updates for drive standby") was hand-patched **only** into the deployed `index.bbceb330.js` bundle — it was never added to the `.vue` source. So once the app became buildable (#14), a real `vite build` from source would silently **drop** standby. This PR ports it back so source is authoritative.

## What
- **`ServerSection.vue`** — average-temperature summary now excludes spun-down drives (which report no temperature) instead of dividing by total disk count, and shows **"All drives are spundown"** when every disk is in standby (vs "No Disks Present" when there are none).
- **`DiskSection.vue`** — adds a **"Power Mode"** detail field for the selected bay.
- **All 31 `P5*.vue` canvas components** — each bay's `standby` state is set from `slot["power-mode"] === "STANDBY"` (in the `diskInfo` watch, the `lsdevJson` watch, and `p5.preload`), and the `p5.draw` loop paints a translucent orange overlay (`fill(255,165,0,80)`) over standby disks.

## Verification (real build, not hand-patched)
Built from source with the vendored deps from #14:
- ✅ `vite build` succeeds
- ✅ `93` standby assignments (31 canvases × 3 sites)
- ✅ `31` standby overlay draws
- ✅ `"Power Mode"` field + `"All drives are spundown"` string present

## Notes
- **Stacked on #14** (`chore/vendor-45drives-deps`) — it needs the vendored deps to build. Base will retarget to `main` once #14 lands. (#14 also got a follow-up fix here for a `.gitignore` that was swallowing the vendored `cockpit-css` compiled entry.)
- The deployed `assets/` bundle is intentionally **not** regenerated in this PR — this makes the *source* correct; reshipping the bundle from a clean build is a separate, QA-gated step (Tailwind 3.4 output differs in formatting from the legacy hand-maintained bundle).
- Applied uniformly to all 31 canvases — slightly broader than the bundle's hand-patch (which covered ~26) — so every chassis behaves consistently.
- ⚠️ Final visual QA (the orange standby overlay across chassis variants) should happen on a real Unraid instance.