### PR TITLE
feat(ui): match Unraid's light/dark color mode

### DIFF
--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/FfdHeader.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/FfdHeader.vue
@@ -28,8 +28,7 @@ If not, see <https://www.gnu.org/licenses/>.
 			</h1>
 		</div>
 		<h1
-			class="text-red-800 dark:text-white text-2xl cursor-pointer grow-0 text-center"
-			@click="home"
+			class="text-red-800 dark:text-white text-2xl grow-0 text-center"
 		>{{ moduleName }}</h1>
 		<div class="flex basis-32 justify-end grow shrink-0">
 			<button
@@ -59,7 +58,29 @@ export default {
 	},
 	setup(props) {
 		const darkMode = props.darkModeInjectionKey ?? ref(true);
+		// When embedded in the Unraid webGUI the plugin runs in a same-origin
+		// iframe whose parent <html> carries Unraid's theme class
+		// (Theme--black / Theme--gray => dark, Theme--white / Theme--azure =>
+		// light). Detect it so the plugin matches Unraid's color mode.
+		function detectUnraidDark() {
+			try {
+				const parentDoc = window.parent && window.parent.document;
+				const parentHtml = parentDoc && parentDoc.documentElement;
+				if (parentHtml && parentHtml !== document.documentElement) {
+					const cls = parentHtml.className || "";
+					if (/\bTheme--(black|gray|dark)\b/.test(cls)) return true;
+					if (/\bTheme--(white|azure|light)\b/.test(cls)) return false;
+				}
+			} catch (e) {
+				// Not embedded, or a cross-origin parent: fall back below.
+			}
+			return null;
+		}
 		function getTheme() {
+			const unraidDark = detectUnraidDark();
+			if (unraidDark !== null)
+				return unraidDark;
+			// Standalone / dev fallback: OS preference, then any saved choice.
 			let prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
 			let theme = localStorage.getItem("color-theme");
 			if (theme === null)
@@ -74,9 +95,6 @@ export default {
 		} else {
 			document.documentElement.classList.remove("dark");
 		}
-		const home = () => {
-			cockpit.location.go('/');
-		};
 		watch(() => darkMode.value, (darkMode, oldDarkMode) => {
 			localStorage.setItem("color-theme", darkMode ? "dark" : "light");
 			if (darkMode) {
@@ -87,7 +105,6 @@ export default {
 		}, { lazy: false });
 		return {
 			darkMode,
-			home,
 		};
 	},
 	components: {

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/FfdHeader.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/FfdHeader.vue
@@ -59,20 +59,44 @@ export default {
 	setup(props) {
 		const darkMode = props.darkModeInjectionKey ?? ref(true);
 		// When embedded in the Unraid webGUI the plugin runs in a same-origin
-		// iframe whose parent <html> carries Unraid's theme class
-		// (Theme--black / Theme--gray => dark, Theme--white / Theme--azure =>
-		// light). Detect it so the plugin matches Unraid's color mode.
-		function detectUnraidDark() {
+		// iframe. The Unraid shell's <html> (and/or <body>) carries the theme
+		// class set by ThemeHelper::getThemeHtmlClass (Theme--black / Theme--gray
+		// => dark, Theme--white / Theme--azure => light). Match it.
+		function themeDarkFrom(win) {
 			try {
-				const parentDoc = window.parent && window.parent.document;
-				const parentHtml = parentDoc && parentDoc.documentElement;
-				if (parentHtml && parentHtml !== document.documentElement) {
-					const cls = parentHtml.className || "";
-					if (/\bTheme--(black|gray|dark)\b/.test(cls)) return true;
-					if (/\bTheme--(white|azure|light)\b/.test(cls)) return false;
+				const doc = win.document;
+				const cls =
+					(doc.documentElement.className || "") +
+					" " +
+					(doc.body ? doc.body.className : "");
+				if (/\bTheme--(black|gray|dark)\b/.test(cls)) return true;
+				if (/\bTheme--(white|azure|light)\b/.test(cls)) return false;
+			} catch (e) {
+				// cross-origin / unavailable window
+			}
+			return null;
+		}
+		function detectUnraidDark() {
+			// The themed shell may be the direct parent or several frames up, so
+			// walk the parent chain and also check the top window.
+			const wins = [];
+			try {
+				let w = window;
+				for (let i = 0; i < 6 && w.parent && w.parent !== w; i++) {
+					w = w.parent;
+					wins.push(w);
 				}
 			} catch (e) {
-				// Not embedded, or a cross-origin parent: fall back below.
+				// frame access blocked
+			}
+			try {
+				if (window.top && wins.indexOf(window.top) === -1) wins.push(window.top);
+			} catch (e) {
+				// top access blocked
+			}
+			for (let i = 0; i < wins.length; i++) {
+				const r = themeDarkFrom(wins[i]);
+				if (r !== null) return r;
 			}
 			return null;
 		}


### PR DESCRIPTION
## What
The Drive Map plugin now **matches Unraid's color mode** instead of defaulting to the OS preference.

It runs in a same-origin iframe inside the Unraid webGUI, whose parent `<html>` carries Unraid's theme class (`ThemeHelper::getThemeHtmlClass()`):
- `Theme--black` / `Theme--gray` → **dark**
- `Theme--white` / `Theme--azure` → **light**

`FfdHeader.vue` reads `window.parent.document.documentElement` and sets the app's dark mode to match. When not embedded (dev/standalone) it falls back to `prefers-color-scheme` / the saved choice. The manual sun/moon toggle still works as a per-session override; on reload it re-syncs to Unraid (which is also when Unraid's own theme change takes effect, since changing it reloads the page).

## Also re-applies the header no-home fix
This branch is stacked on the vendoring branch (#14), which predates the merged header fix (#13). Since I was editing the same component, I also removed the title's `home()` click (`cockpit.location.go('/')`) that reloaded the whole webGUI into the iframe — so a from-source build doesn't reintroduce that bug.

## Verification
- Builds clean; bundle contains the `Theme--` detection and no longer contains `cockpit.location.go`.
- Confirmed on-box that Unraid sets `Theme--{black|gray|white|azure}` on the parent `<html>` (Titan currently `black` → dark).
- Deployed in the full-stack build to devgen.local and Titan for live QA.

## Notes
- Stacked on #14 (needs the vendored deps to build). Retarget to `main` once #14 lands.
- ⚠️ Visual QA: switch Unraid Settings → Display Settings theme between a light (white/azure) and dark (black/gray) theme and confirm the Drive Map follows after the page reload.