### PR TITLE
Build from source: vendored deps + standby, theme, and storage features

### DIFF
--- a/vendor/45drives/cockpit-hardware/45drives-disks/package-lock.json
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/package-lock.json
@@ -1,14 +1,13 @@
 {
   "name": "45drives-disks",
   "version": "0.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "45drives-disks",
       "version": "0.0.0",
       "dependencies": {
-        "@45drives/cockpit-css": "^0.1.12",
         "@fontsource/red-hat-text": "^4.5.4",
         "@headlessui/vue": "^1.5.0",
         "@heroicons/vue": "^1.0.6",
@@ -18,7 +17,6 @@
         "vue": "^3.2.25"
       },
       "devDependencies": {
-        "@45drives/cockpit-helpers": "^0.1.9",
         "@vitejs/plugin-vue": "^2.2.0",
         "autoprefixer": "10.4.5",
         "postcss": "^8.4.12",
@@ -27,23 +25,44 @@
         "vite": "^2.8.0"
       }
     },
-    "node_modules/@45drives/cockpit-css": {
-      "version": "0.1.12",
-      "resolved": "https://npm.pkg.github.com/download/@45drives/cockpit-css/0.1.12/b5d0b428714271695e5e0af9932b87e26456156e53aa99fbbb4431be0c4c8880",
-      "integrity": "sha512-RgyedX/5GuriDvLruvmbqb++cIBqIF5py2E4G8/wMtQfUf6QnJqsRLYNp7uzKcLpE2+kjm9pGASdvwV2I2b/YA==",
-      "license": "GPLv3"
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
-    "node_modules/@45drives/cockpit-helpers": {
-      "version": "0.1.9",
-      "resolved": "https://npm.pkg.github.com/download/@45drives/cockpit-helpers/0.1.9/1b89ca1db889b979029f709808f6e19f277274687056ee600396f2c17a8c51c9",
-      "integrity": "sha512-KNrPpcC5ipra+JWkKgBs18dAHUFdHDsce0sRI4Nb5Q8nwdWoaVMt5TEbIorRxxI5VlfhcYCl1xfDl+WSNKCvLw==",
-      "dev": true,
-      "license": "GPLv3"
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
-      "integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -51,15 +70,50 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
+      "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@fontsource/red-hat-text": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@fontsource/red-hat-text/-/red-hat-text-4.5.9.tgz",
-      "integrity": "sha512-7jBq3vSTtZt1kJpwRt04EFfAGepY2E9eq7p09zyD4Ibx0rItBy/uoF/6Wmx/1heJurbUxxcBHY/6dKNxBRpb4g=="
+      "version": "4.5.12",
+      "resolved": "https://registry.npmjs.org/@fontsource/red-hat-text/-/red-hat-text-4.5.12.tgz",
+      "integrity": "sha512-404lUG4USsR9s0kmMAPmistREqXETYShCH7AhCNDe+6xEGZraaDatsbjr0zbI/4zd2Oxz/s+n3Q2miDDVsQSFA==",
+      "license": "MIT"
     },
     "node_modules/@headlessui/vue": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@headlessui/vue/-/vue-1.6.1.tgz",
-      "integrity": "sha512-fccGN1hsFvS0P73NplZoOdX1rhyaH5jIQE9IUKNaaJC72mQjR3lVvZldo+iiLF5X1bqgl6pDixWdqS2kMGfFxA==",
+      "version": "1.7.23",
+      "resolved": "https://registry.npmjs.org/@headlessui/vue/-/vue-1.7.23.tgz",
+      "integrity": "sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/vue-virtual": "^3.0.0-beta.60"
+      },
       "engines": {
         "node": ">=10"
       },
@@ -71,14 +125,51 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@heroicons/vue/-/vue-1.0.6.tgz",
       "integrity": "sha512-ng2YcCQrdoQWEFpw+ipFl2rZo8mZ56v0T5+MyfQQvNqfKChwgP6DMloZLW+rl17GEcHkE3H82UTAMKBKZr4+WA==",
+      "license": "MIT",
       "peerDependencies": {
         "vue": ">= 3"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -91,6 +182,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -99,6 +191,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -108,21 +201,49 @@
       }
     },
     "node_modules/@tailwindcss/forms": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.1.tgz",
-      "integrity": "sha512-QSwsFORnC2BAP0lRzQkz1pw+EzIiiPdk4e27vGQjyXkwJPeC7iLIRVndJzf9CJVbcrrIcirb/TfxF3gRTyFEVA==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.11.tgz",
+      "integrity": "sha512-h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA==",
+      "license": "MIT",
       "dependencies": {
         "mini-svg-data-uri": "^1.2.3"
       },
       "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-virtual": {
+      "version": "3.13.29",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.29.tgz",
+      "integrity": "sha512-MWb9tNHjpar3sP34b8+3A4I5j9akveoPXIYqqp7/ipyWd49a/kso+1S1LqEmAVR/+g/k1WWTJC4ktvdCGWgXYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.0.0"
       }
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.2.tgz",
-      "integrity": "sha512-umyypfSHS4kQLdYAnJHhaASq7FRzNCdvcRoQ3uYGNk1/M4a+hXUd7ysN7BLhCrWH6uBokyCkFeUAaFDzSaaSrQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.4.tgz",
+      "integrity": "sha512-IfFNbtkbIm36O9KB8QodlwwYvTEsJb4Lll4c2IwB3VHc2gie2mSPtSzL0eYay7X2jd/2WX02FjSGTWR6OPr/zg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -132,140 +253,116 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.33.tgz",
-      "integrity": "sha512-AAmr52ji3Zhk7IKIuigX2osWWsb2nQE5xsdFYjdnmtQ4gymmqXbjLvkSE174+fF3A3kstYrTgGkqgOEbsdLDpw==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
+      "integrity": "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.33",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.38",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.33.tgz",
-      "integrity": "sha512-GhiG1C8X98Xz9QUX/RlA6/kgPBWJkjq0Rq6//5XTAGSYrTMBgcLpP9+CnlUg1TFxnnCVughAG+KZl28XJqw8uQ==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.38.tgz",
+      "integrity": "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.2.33",
-        "@vue/shared": "3.2.33"
+        "@vue/compiler-core": "3.5.38",
+        "@vue/shared": "3.5.38"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.33.tgz",
-      "integrity": "sha512-H8D0WqagCr295pQjUYyO8P3IejM3vEzeCO1apzByAEaAR/WimhMYczHfZVvlCE/9yBaEu/eu9RdiWr0kF8b71Q==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.38.tgz",
+      "integrity": "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.33",
-        "@vue/compiler-dom": "3.2.33",
-        "@vue/compiler-ssr": "3.2.33",
-        "@vue/reactivity-transform": "3.2.33",
-        "@vue/shared": "3.2.33",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.38",
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/compiler-ssr": "3.5.38",
+        "@vue/shared": "3.5.38",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7",
-        "postcss": "^8.1.10",
-        "source-map": "^0.6.1"
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.33.tgz",
-      "integrity": "sha512-XQh1Xdk3VquDpXsnoCd7JnMoWec9CfAzQDQsaMcSU79OrrO2PNR0ErlIjm/mGq3GmBfkQjzZACV+7GhfRB8xMQ==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.38.tgz",
+      "integrity": "sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.2.33",
-        "@vue/shared": "3.2.33"
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/shared": "3.5.38"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.33.tgz",
-      "integrity": "sha512-62Sq0mp9/0bLmDuxuLD5CIaMG2susFAGARLuZ/5jkU1FCf9EDbwUuF+BO8Ub3Rbodx0ziIecM/NsmyjardBxfQ==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.38.tgz",
+      "integrity": "sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "node_modules/@vue/reactivity-transform": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.33.tgz",
-      "integrity": "sha512-4UL5KOIvSQb254aqenW4q34qMXbfZcmEsV/yVidLUgvwYQQ/D21bGX3DlgPUGI3c4C+iOnNmDCkIxkILoX/Pyw==",
-      "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.33",
-        "@vue/shared": "3.2.33",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7"
+        "@vue/shared": "3.5.38"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.33.tgz",
-      "integrity": "sha512-N2D2vfaXsBPhzCV3JsXQa2NECjxP3eXgZlFqKh4tgakp3iX6LCGv76DLlc+IfFZq+TW10Y8QUfeihXOupJ1dGw==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.38.tgz",
+      "integrity": "sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.2.33",
-        "@vue/shared": "3.2.33"
+        "@vue/reactivity": "3.5.38",
+        "@vue/shared": "3.5.38"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.33.tgz",
-      "integrity": "sha512-LSrJ6W7CZTSUygX5s8aFkraDWlO6K4geOwA3quFF2O+hC3QuAMZt/0Xb7JKE3C4JD4pFwCSO7oCrZmZ0BIJUnw==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.38.tgz",
+      "integrity": "sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/runtime-core": "3.2.33",
-        "@vue/shared": "3.2.33",
-        "csstype": "^2.6.8"
+        "@vue/reactivity": "3.5.38",
+        "@vue/runtime-core": "3.5.38",
+        "@vue/shared": "3.5.38",
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.33.tgz",
-      "integrity": "sha512-4jpJHRD4ORv8PlbYi+/MfP8ec1okz6rybe36MdpkDrGIdEItHEUyaHSKvz+ptNEyQpALmmVfRteHkU9F8vxOew==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.38.tgz",
+      "integrity": "sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.2.33",
-        "@vue/shared": "3.2.33"
+        "@vue/compiler-ssr": "3.5.38",
+        "@vue/shared": "3.5.38"
       },
       "peerDependencies": {
-        "vue": "3.2.33"
+        "vue": "3.5.38"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.33.tgz",
-      "integrity": "sha512-UBc1Pg1T3yZ97vsA2ueER0F6GbJebLHYlEi4ou1H5YL4KWvMOOWwpYo9/QpWq93wxKG6Wo13IY74Hcn/f7c7Bg=="
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
+      "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
+      "license": "MIT"
     },
-    "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-node": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
-      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
-      "dependencies": {
-        "acorn": "^7.0.0",
-        "acorn-walk": "^7.0.0",
-        "xtend": "^4.0.2"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
     },
     "node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -275,9 +372,10 @@
       }
     },
     "node_modules/arg": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
-      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA=="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.5",
@@ -294,6 +392,7 @@
           "url": "https://tidelift.com/funding/github/npm/autoprefixer"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "browserslist": "^4.20.2",
         "caniuse-lite": "^1.0.30001332",
@@ -312,29 +411,47 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
         {
@@ -344,14 +461,19 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001332",
-        "electron-to-chromium": "^1.4.118",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.3",
-        "picocolors": "^1.0.0"
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -364,14 +486,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001338",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
-      "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -381,19 +504,19 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        }
-      ]
-    },
-    "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "funding": [
+        },
         {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -406,6 +529,9 @@
       "engines": {
         "node": ">= 8.10.0"
       },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
@@ -414,6 +540,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -421,15 +548,20 @@
         "node": ">= 6"
       }
     },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -438,53 +570,58 @@
       }
     },
     "node_modules/csstype": {
-      "version": "2.6.20",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
-      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
-    },
-    "node_modules/defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM= sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
-    },
-    "node_modules/detective": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
-      "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
-      "dependencies": {
-        "acorn-node": "^1.6.1",
-        "defined": "^1.0.0",
-        "minimist": "^1.1.1"
-      },
-      "bin": {
-        "detective": "bin/detective.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.137",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
-      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
-      "dev": true
+      "version": "1.5.378",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.378.tgz",
+      "integrity": "sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.38.tgz",
-      "integrity": "sha512-12fzJ0fsm7gVZX1YQ1InkOE5f9Tl7cgf6JPYXRJtPIoE0zkWAbHdPHVPPaLi9tYAcEBqheGzqLn/3RdTOyBfcA==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
+      "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -492,36 +629,38 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "esbuild-android-64": "0.14.38",
-        "esbuild-android-arm64": "0.14.38",
-        "esbuild-darwin-64": "0.14.38",
-        "esbuild-darwin-arm64": "0.14.38",
-        "esbuild-freebsd-64": "0.14.38",
-        "esbuild-freebsd-arm64": "0.14.38",
-        "esbuild-linux-32": "0.14.38",
-        "esbuild-linux-64": "0.14.38",
-        "esbuild-linux-arm": "0.14.38",
-        "esbuild-linux-arm64": "0.14.38",
-        "esbuild-linux-mips64le": "0.14.38",
-        "esbuild-linux-ppc64le": "0.14.38",
-        "esbuild-linux-riscv64": "0.14.38",
-        "esbuild-linux-s390x": "0.14.38",
-        "esbuild-netbsd-64": "0.14.38",
-        "esbuild-openbsd-64": "0.14.38",
-        "esbuild-sunos-64": "0.14.38",
-        "esbuild-windows-32": "0.14.38",
-        "esbuild-windows-64": "0.14.38",
-        "esbuild-windows-arm64": "0.14.38"
+        "@esbuild/linux-loong64": "0.14.54",
+        "esbuild-android-64": "0.14.54",
+        "esbuild-android-arm64": "0.14.54",
+        "esbuild-darwin-64": "0.14.54",
+        "esbuild-darwin-arm64": "0.14.54",
+        "esbuild-freebsd-64": "0.14.54",
+        "esbuild-freebsd-arm64": "0.14.54",
+        "esbuild-linux-32": "0.14.54",
+        "esbuild-linux-64": "0.14.54",
+        "esbuild-linux-arm": "0.14.54",
+        "esbuild-linux-arm64": "0.14.54",
+        "esbuild-linux-mips64le": "0.14.54",
+        "esbuild-linux-ppc64le": "0.14.54",
+        "esbuild-linux-riscv64": "0.14.54",
+        "esbuild-linux-s390x": "0.14.54",
+        "esbuild-netbsd-64": "0.14.54",
+        "esbuild-openbsd-64": "0.14.54",
+        "esbuild-sunos-64": "0.14.54",
+        "esbuild-windows-32": "0.14.54",
+        "esbuild-windows-64": "0.14.54",
+        "esbuild-windows-arm64": "0.14.54"
       }
     },
     "node_modules/esbuild-android-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.38.tgz",
-      "integrity": "sha512-aRFxR3scRKkbmNuGAK+Gee3+yFxkTJO/cx83Dkyzo4CnQl/2zVSurtG6+G86EQIZ+w+VYngVyK7P3HyTBKu3nw==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
+      "integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -531,13 +670,14 @@
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.38.tgz",
-      "integrity": "sha512-L2NgQRWuHFI89IIZIlpAcINy9FvBk6xFVZ7xGdOwIm8VyhX1vNCEqUJO3DPSSy945Gzdg98cxtNt8Grv1CsyhA==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
+      "integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -547,13 +687,14 @@
       }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.38.tgz",
-      "integrity": "sha512-5JJvgXkX87Pd1Og0u/NJuO7TSqAikAcQQ74gyJ87bqWRVeouky84ICoV4sN6VV53aTW+NE87qLdGY4QA2S7KNA==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
+      "integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -563,13 +704,14 @@
       }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.38.tgz",
-      "integrity": "sha512-eqF+OejMI3mC5Dlo9Kdq/Ilbki9sQBw3QlHW3wjLmsLh+quNfHmGMp3Ly1eWm981iGBMdbtSS9+LRvR2T8B3eQ==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
+      "integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -579,13 +721,14 @@
       }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.38.tgz",
-      "integrity": "sha512-epnPbhZUt93xV5cgeY36ZxPXDsQeO55DppzsIgWM8vgiG/Rz+qYDLmh5ts3e+Ln1wA9dQ+nZmVHw+RjaW3I5Ig==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
+      "integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -595,13 +738,14 @@
       }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.38.tgz",
-      "integrity": "sha512-/9icXUYJWherhk+y5fjPI5yNUdFPtXHQlwP7/K/zg8t8lQdHVj20SqU9/udQmeUo5pDFHMYzcEFfJqgOVeKNNQ==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
+      "integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -611,13 +755,14 @@
       }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.38.tgz",
-      "integrity": "sha512-QfgfeNHRFvr2XeHFzP8kOZVnal3QvST3A0cgq32ZrHjSMFTdgXhMhmWdKzRXP/PKcfv3e2OW9tT9PpcjNvaq6g==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
+      "integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -627,13 +772,14 @@
       }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.38.tgz",
-      "integrity": "sha512-uuZHNmqcs+Bj1qiW9k/HZU3FtIHmYiuxZ/6Aa+/KHb/pFKr7R3aVqvxlAudYI9Fw3St0VCPfv7QBpUITSmBR1Q==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
+      "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -643,13 +789,14 @@
       }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.38.tgz",
-      "integrity": "sha512-FiFvQe8J3VKTDXG01JbvoVRXQ0x6UZwyrU4IaLBZeq39Bsbatd94Fuc3F1RGqPF5RbIWW7RvkVQjn79ejzysnA==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
+      "integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -659,13 +806,14 @@
       }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.38.tgz",
-      "integrity": "sha512-HlMGZTEsBrXrivr64eZ/EO0NQM8H8DuSENRok9d+Jtvq8hOLzrxfsAT9U94K3KOGk2XgCmkaI2KD8hX7F97lvA==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
+      "integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -675,13 +823,14 @@
       }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.38.tgz",
-      "integrity": "sha512-qd1dLf2v7QBiI5wwfil9j0HG/5YMFBAmMVmdeokbNAMbcg49p25t6IlJFXAeLzogv1AvgaXRXvgFNhScYEUXGQ==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
+      "integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
       "cpu": [
         "mips64el"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -691,13 +840,14 @@
       }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.38.tgz",
-      "integrity": "sha512-mnbEm7o69gTl60jSuK+nn+pRsRHGtDPfzhrqEUXyCl7CTOCLtWN2bhK8bgsdp6J/2NyS/wHBjs1x8aBWwP2X9Q==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
+      "integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -707,13 +857,14 @@
       }
     },
     "node_modules/esbuild-linux-riscv64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.38.tgz",
-      "integrity": "sha512-+p6YKYbuV72uikChRk14FSyNJZ4WfYkffj6Af0/Tw63/6TJX6TnIKE+6D3xtEc7DeDth1fjUOEqm+ApKFXbbVQ==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
+      "integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -723,13 +874,14 @@
       }
     },
     "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.38.tgz",
-      "integrity": "sha512-0zUsiDkGJiMHxBQ7JDU8jbaanUY975CdOW1YDrurjrM0vWHfjv9tLQsW9GSyEb/heSK1L5gaweRjzfUVBFoybQ==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
+      "integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -739,13 +891,14 @@
       }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.38.tgz",
-      "integrity": "sha512-cljBAApVwkpnJZfnRVThpRBGzCi+a+V9Ofb1fVkKhtrPLDYlHLrSYGtmnoTVWDQdU516qYI8+wOgcGZ4XIZh0Q==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
+      "integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -755,13 +908,14 @@
       }
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.38.tgz",
-      "integrity": "sha512-CDswYr2PWPGEPpLDUO50mL3WO/07EMjnZDNKpmaxUPsrW+kVM3LoAqr/CE8UbzugpEiflYqJsGPLirThRB18IQ==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
+      "integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -771,13 +925,14 @@
       }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.38.tgz",
-      "integrity": "sha512-2mfIoYW58gKcC3bck0j7lD3RZkqYA7MmujFYmSn9l6TiIcAMpuEvqksO+ntBgbLep/eyjpgdplF7b+4T9VJGOA==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
+      "integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -787,13 +942,14 @@
       }
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.38.tgz",
-      "integrity": "sha512-L2BmEeFZATAvU+FJzJiRLFUP+d9RHN+QXpgaOrs2klshoAm1AE6Us4X6fS9k33Uy5SzScn2TpcgecbqJza1Hjw==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
+      "integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -803,13 +959,14 @@
       }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.38.tgz",
-      "integrity": "sha512-Khy4wVmebnzue8aeSXLC+6clo/hRYeNIm0DyikoEqX+3w3rcvrhzpoix0S+MF9vzh6JFskkIGD7Zx47ODJNyCw==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
+      "integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -819,13 +976,14 @@
       }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.38.tgz",
-      "integrity": "sha512-k3FGCNmHBkqdJXuJszdWciAH77PukEyDsdIryEHn9cKLQFxzhT39dSumeTuggaQcXY57UlmLGIkklWZo2qzHpw==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
+      "integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -835,10 +993,11 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -846,18 +1005,20 @@
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -867,6 +1028,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -875,17 +1037,19 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -894,23 +1058,25 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       },
       "funding": {
         "type": "patreon",
-        "url": "https://www.patreon.com/infusion"
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -920,14 +1086,19 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -935,21 +1106,23 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1"
+        "function-bind": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.4.0"
+        "node": ">= 0.4"
       }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -958,11 +1131,15 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -971,7 +1148,8 @@
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI= sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -980,6 +1158,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -991,40 +1170,63 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
     },
-    "node_modules/lilconfig": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
-      "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
-      "engines": {
-        "node": ">=10"
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
       "dependencies": {
-        "sourcemap-codec": "^1.4.8"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -1035,19 +1237,33 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
       "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "license": "MIT",
       "bin": {
         "mini-svg-data-uri": "cli.js"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -1056,15 +1272,20 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
-      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
-      "dev": true
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1072,8 +1293,18 @@
     "node_modules/normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI= sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1082,29 +1313,34 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/p5": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/p5/-/p5-1.4.1.tgz",
-      "integrity": "sha512-3/X+qb0bK2Cg8nuZNpZZvzxkeUSRghOf0S+l8c+U8yIkUTVSbbcV0R8y96rx3InVBVhk8cH9kFC93VlZZElqSw=="
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/p5/-/p5-1.11.13.tgz",
+      "integrity": "sha512-gfGo4AkyuNMs6Ko7UNFM9K2edqFRGyLrFaYUB+XXF127JVdEPu0BIaC5uDDNJpsRMOD9hJMUpsOH4HkfuNhvhA==",
+      "license": "LGPL-2.1"
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -1115,16 +1351,25 @@
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw= sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/postcss": {
-      "version": "8.4.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
-      "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -1133,12 +1378,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.3",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -1149,6 +1399,7 @@
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
       "integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -1162,73 +1413,102 @@
       }
     },
     "node_modules/postcss-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.0.tgz",
-      "integrity": "sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
       },
       "engines": {
         "node": "^12 || ^14 || >= 16"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
       "peerDependencies": {
-        "postcss": "^8.3.3"
+        "postcss": "^8.4.21"
       }
     },
     "node_modules/postcss-load-config": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
-      "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "lilconfig": "^2.0.5",
-        "yaml": "^1.10.2"
+        "lilconfig": "^3.1.1"
       },
       "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
+        "node": ">= 18"
       },
       "peerDependencies": {
+        "jiti": ">=1.21.0",
         "postcss": ">=8.0.9",
-        "ts-node": ">=9.0.0"
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
         "postcss": {
           "optional": true
         },
-        "ts-node": {
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
           "optional": true
         }
       }
     },
     "node_modules/postcss-nested": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
-      "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.6"
+        "postcss-selector-parser": "^6.1.1"
       },
       "engines": {
         "node": ">=12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
       },
       "peerDependencies": {
         "postcss": "^8.2.14"
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
-      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -1240,7 +1520,8 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -1259,24 +1540,14 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
-    },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      ],
+      "license": "MIT"
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q= sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
       }
@@ -1285,6 +1556,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -1293,35 +1565,42 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.8.1",
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
       },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
-      "version": "2.72.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.72.1.tgz",
-      "integrity": "sha512-NTc5UGy/NWFGpSqF1lFY8z9Adri6uhyMLI6LvPAXdBKoPRFhIIiBUpt+Qg2awixqO3xvzSijjhnb4+QEZwJmxA==",
+      "version": "2.77.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
+      "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -1350,22 +1629,16 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1374,18 +1647,36 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/source-sans-pro/-/source-sans-pro-3.6.0.tgz",
       "integrity": "sha512-C1RFUGu+YASuqpgDRInTM7Y6OwqeWNOuKn7v0P/4Kh66epTI4PYWwPWP5kdA4l/VqzBAWiqoz5dk0trof73R7w==",
-      "deprecated": "WARNING: This project has been renamed to source-sans. Install using source-sans instead."
+      "deprecated": "WARNING: This project has been renamed to source-sans. Install using source-sans instead.",
+      "license": "OFL-1.1"
     },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead"
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -1394,47 +1685,130 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.0.24",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.24.tgz",
-      "integrity": "sha512-H3uMmZNWzG6aqmg9q07ZIRNIawoiEcNFKDfL+YzOPuPsXuDXxJxB9icqzLgdzKNwjG3SAro2h9SYav8ewXNgig==",
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "license": "MIT",
       "dependencies": {
-        "arg": "^5.0.1",
-        "chokidar": "^3.5.3",
-        "color-name": "^1.1.4",
-        "detective": "^5.2.0",
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.2.11",
+        "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "lilconfig": "^2.0.5",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
-        "picocolors": "^1.0.0",
-        "postcss": "^8.4.12",
-        "postcss-js": "^4.0.0",
-        "postcss-load-config": "^3.1.4",
-        "postcss-nested": "5.0.6",
-        "postcss-selector-parser": "^6.0.10",
-        "postcss-value-parser": "^4.2.0",
-        "quick-lru": "^5.1.1",
-        "resolve": "^1.22.0"
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
       },
       "bin": {
         "tailwind": "lib/cli.js",
         "tailwindcss": "lib/cli.js"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "postcss": "^8.0.9"
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -1442,21 +1816,60 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8= sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "2.9.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.8.tgz",
-      "integrity": "sha512-zsBGwn5UT3YS0NLSJ7hnR54+vUKfgzMUh/Z9CxF1YKEBVIe213+63jrFLmZphgGI5zXwQCSmqIdbPuE8NJywPw==",
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.18.tgz",
+      "integrity": "sha512-sAOqI5wNM9QvSEE70W3UGMdT8cyEn0+PmJMTFvTB8wB0YbYUWw3gUbY62AOyrXosGieF2htmeLATvNxpv/zNyQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.14.27",
         "postcss": "^8.4.13",
         "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "rollup": ">=2.59.0 <2.78.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -1485,954 +1898,25 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.33.tgz",
-      "integrity": "sha512-si1ExAlDUrLSIg/V7D/GgA4twJwfsfgG+t9w10z38HhL/HA07132pUQ2KuwAo8qbCyMJ9e6OqrmWrOCr+jW7ZQ==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.38.tgz",
+      "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.2.33",
-        "@vue/compiler-sfc": "3.2.33",
-        "@vue/runtime-dom": "3.2.33",
-        "@vue/server-renderer": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "engines": {
-        "node": ">= 6"
-      }
-    }
-  },
-  "dependencies": {
-    "@45drives/cockpit-css": {
-      "version": "0.1.12",
-      "resolved": "https://npm.pkg.github.com/download/@45drives/cockpit-css/0.1.12/b5d0b428714271695e5e0af9932b87e26456156e53aa99fbbb4431be0c4c8880",
-      "integrity": "sha512-RgyedX/5GuriDvLruvmbqb++cIBqIF5py2E4G8/wMtQfUf6QnJqsRLYNp7uzKcLpE2+kjm9pGASdvwV2I2b/YA=="
-    },
-    "@45drives/cockpit-helpers": {
-      "version": "0.1.9",
-      "resolved": "https://npm.pkg.github.com/download/@45drives/cockpit-helpers/0.1.9/1b89ca1db889b979029f709808f6e19f277274687056ee600396f2c17a8c51c9",
-      "integrity": "sha512-KNrPpcC5ipra+JWkKgBs18dAHUFdHDsce0sRI4Nb5Q8nwdWoaVMt5TEbIorRxxI5VlfhcYCl1xfDl+WSNKCvLw==",
-      "dev": true
-    },
-    "@babel/parser": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
-      "integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ=="
-    },
-    "@fontsource/red-hat-text": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@fontsource/red-hat-text/-/red-hat-text-4.5.9.tgz",
-      "integrity": "sha512-7jBq3vSTtZt1kJpwRt04EFfAGepY2E9eq7p09zyD4Ibx0rItBy/uoF/6Wmx/1heJurbUxxcBHY/6dKNxBRpb4g=="
-    },
-    "@headlessui/vue": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@headlessui/vue/-/vue-1.6.1.tgz",
-      "integrity": "sha512-fccGN1hsFvS0P73NplZoOdX1rhyaH5jIQE9IUKNaaJC72mQjR3lVvZldo+iiLF5X1bqgl6pDixWdqS2kMGfFxA==",
-      "requires": {}
-    },
-    "@heroicons/vue": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@heroicons/vue/-/vue-1.0.6.tgz",
-      "integrity": "sha512-ng2YcCQrdoQWEFpw+ipFl2rZo8mZ56v0T5+MyfQQvNqfKChwgP6DMloZLW+rl17GEcHkE3H82UTAMKBKZr4+WA==",
-      "requires": {}
-    },
-    "@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "requires": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      }
-    },
-    "@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
-    },
-    "@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "requires": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      }
-    },
-    "@tailwindcss/forms": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.1.tgz",
-      "integrity": "sha512-QSwsFORnC2BAP0lRzQkz1pw+EzIiiPdk4e27vGQjyXkwJPeC7iLIRVndJzf9CJVbcrrIcirb/TfxF3gRTyFEVA==",
-      "requires": {
-        "mini-svg-data-uri": "^1.2.3"
-      }
-    },
-    "@vitejs/plugin-vue": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.2.tgz",
-      "integrity": "sha512-umyypfSHS4kQLdYAnJHhaASq7FRzNCdvcRoQ3uYGNk1/M4a+hXUd7ysN7BLhCrWH6uBokyCkFeUAaFDzSaaSrQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "@vue/compiler-core": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.33.tgz",
-      "integrity": "sha512-AAmr52ji3Zhk7IKIuigX2osWWsb2nQE5xsdFYjdnmtQ4gymmqXbjLvkSE174+fF3A3kstYrTgGkqgOEbsdLDpw==",
-      "requires": {
-        "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.33",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      }
-    },
-    "@vue/compiler-dom": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.33.tgz",
-      "integrity": "sha512-GhiG1C8X98Xz9QUX/RlA6/kgPBWJkjq0Rq6//5XTAGSYrTMBgcLpP9+CnlUg1TFxnnCVughAG+KZl28XJqw8uQ==",
-      "requires": {
-        "@vue/compiler-core": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "@vue/compiler-sfc": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.33.tgz",
-      "integrity": "sha512-H8D0WqagCr295pQjUYyO8P3IejM3vEzeCO1apzByAEaAR/WimhMYczHfZVvlCE/9yBaEu/eu9RdiWr0kF8b71Q==",
-      "requires": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.33",
-        "@vue/compiler-dom": "3.2.33",
-        "@vue/compiler-ssr": "3.2.33",
-        "@vue/reactivity-transform": "3.2.33",
-        "@vue/shared": "3.2.33",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7",
-        "postcss": "^8.1.10",
-        "source-map": "^0.6.1"
-      }
-    },
-    "@vue/compiler-ssr": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.33.tgz",
-      "integrity": "sha512-XQh1Xdk3VquDpXsnoCd7JnMoWec9CfAzQDQsaMcSU79OrrO2PNR0ErlIjm/mGq3GmBfkQjzZACV+7GhfRB8xMQ==",
-      "requires": {
-        "@vue/compiler-dom": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "@vue/reactivity": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.33.tgz",
-      "integrity": "sha512-62Sq0mp9/0bLmDuxuLD5CIaMG2susFAGARLuZ/5jkU1FCf9EDbwUuF+BO8Ub3Rbodx0ziIecM/NsmyjardBxfQ==",
-      "requires": {
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "@vue/reactivity-transform": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.33.tgz",
-      "integrity": "sha512-4UL5KOIvSQb254aqenW4q34qMXbfZcmEsV/yVidLUgvwYQQ/D21bGX3DlgPUGI3c4C+iOnNmDCkIxkILoX/Pyw==",
-      "requires": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.33",
-        "@vue/shared": "3.2.33",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7"
-      }
-    },
-    "@vue/runtime-core": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.33.tgz",
-      "integrity": "sha512-N2D2vfaXsBPhzCV3JsXQa2NECjxP3eXgZlFqKh4tgakp3iX6LCGv76DLlc+IfFZq+TW10Y8QUfeihXOupJ1dGw==",
-      "requires": {
-        "@vue/reactivity": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "@vue/runtime-dom": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.33.tgz",
-      "integrity": "sha512-LSrJ6W7CZTSUygX5s8aFkraDWlO6K4geOwA3quFF2O+hC3QuAMZt/0Xb7JKE3C4JD4pFwCSO7oCrZmZ0BIJUnw==",
-      "requires": {
-        "@vue/runtime-core": "3.2.33",
-        "@vue/shared": "3.2.33",
-        "csstype": "^2.6.8"
-      }
-    },
-    "@vue/server-renderer": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.33.tgz",
-      "integrity": "sha512-4jpJHRD4ORv8PlbYi+/MfP8ec1okz6rybe36MdpkDrGIdEItHEUyaHSKvz+ptNEyQpALmmVfRteHkU9F8vxOew==",
-      "requires": {
-        "@vue/compiler-ssr": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "@vue/shared": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.33.tgz",
-      "integrity": "sha512-UBc1Pg1T3yZ97vsA2ueER0F6GbJebLHYlEi4ou1H5YL4KWvMOOWwpYo9/QpWq93wxKG6Wo13IY74Hcn/f7c7Bg=="
-    },
-    "acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
-    },
-    "acorn-node": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
-      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
-      "requires": {
-        "acorn": "^7.0.0",
-        "acorn-walk": "^7.0.0",
-        "xtend": "^4.0.2"
-      }
-    },
-    "acorn-walk": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
-    },
-    "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      }
-    },
-    "arg": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
-      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA=="
-    },
-    "autoprefixer": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
-      "integrity": "sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.20.2",
-        "caniuse-lite": "^1.0.30001332",
-        "fraction.js": "^4.2.0",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
-    },
-    "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "requires": {
-        "fill-range": "^7.0.1"
-      }
-    },
-    "browserslist": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
-      "dev": true,
-      "requires": {
-        "caniuse-lite": "^1.0.30001332",
-        "electron-to-chromium": "^1.4.118",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.3",
-        "picocolors": "^1.0.0"
-      }
-    },
-    "camelcase-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
-    },
-    "caniuse-lite": {
-      "version": "1.0.30001338",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
-      "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
-      "dev": true
-    },
-    "chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "requires": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/compiler-sfc": "3.5.38",
+        "@vue/runtime-dom": "3.5.38",
+        "@vue/server-renderer": "3.5.38",
+        "@vue/shared": "3.5.38"
       },
-      "dependencies": {
-        "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
         }
       }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
-    },
-    "csstype": {
-      "version": "2.6.20",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
-      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
-    },
-    "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM= sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
-    },
-    "detective": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
-      "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
-      "requires": {
-        "acorn-node": "^1.6.1",
-        "defined": "^1.0.0",
-        "minimist": "^1.1.1"
-      }
-    },
-    "didyoumean": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
-    },
-    "dlv": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
-    },
-    "electron-to-chromium": {
-      "version": "1.4.137",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
-      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
-      "dev": true
-    },
-    "esbuild": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.38.tgz",
-      "integrity": "sha512-12fzJ0fsm7gVZX1YQ1InkOE5f9Tl7cgf6JPYXRJtPIoE0zkWAbHdPHVPPaLi9tYAcEBqheGzqLn/3RdTOyBfcA==",
-      "dev": true,
-      "requires": {
-        "esbuild-android-64": "0.14.38",
-        "esbuild-android-arm64": "0.14.38",
-        "esbuild-darwin-64": "0.14.38",
-        "esbuild-darwin-arm64": "0.14.38",
-        "esbuild-freebsd-64": "0.14.38",
-        "esbuild-freebsd-arm64": "0.14.38",
-        "esbuild-linux-32": "0.14.38",
-        "esbuild-linux-64": "0.14.38",
-        "esbuild-linux-arm": "0.14.38",
-        "esbuild-linux-arm64": "0.14.38",
-        "esbuild-linux-mips64le": "0.14.38",
-        "esbuild-linux-ppc64le": "0.14.38",
-        "esbuild-linux-riscv64": "0.14.38",
-        "esbuild-linux-s390x": "0.14.38",
-        "esbuild-netbsd-64": "0.14.38",
-        "esbuild-openbsd-64": "0.14.38",
-        "esbuild-sunos-64": "0.14.38",
-        "esbuild-windows-32": "0.14.38",
-        "esbuild-windows-64": "0.14.38",
-        "esbuild-windows-arm64": "0.14.38"
-      }
-    },
-    "esbuild-android-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.38.tgz",
-      "integrity": "sha512-aRFxR3scRKkbmNuGAK+Gee3+yFxkTJO/cx83Dkyzo4CnQl/2zVSurtG6+G86EQIZ+w+VYngVyK7P3HyTBKu3nw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-android-arm64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.38.tgz",
-      "integrity": "sha512-L2NgQRWuHFI89IIZIlpAcINy9FvBk6xFVZ7xGdOwIm8VyhX1vNCEqUJO3DPSSy945Gzdg98cxtNt8Grv1CsyhA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-darwin-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.38.tgz",
-      "integrity": "sha512-5JJvgXkX87Pd1Og0u/NJuO7TSqAikAcQQ74gyJ87bqWRVeouky84ICoV4sN6VV53aTW+NE87qLdGY4QA2S7KNA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-darwin-arm64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.38.tgz",
-      "integrity": "sha512-eqF+OejMI3mC5Dlo9Kdq/Ilbki9sQBw3QlHW3wjLmsLh+quNfHmGMp3Ly1eWm981iGBMdbtSS9+LRvR2T8B3eQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.38.tgz",
-      "integrity": "sha512-epnPbhZUt93xV5cgeY36ZxPXDsQeO55DppzsIgWM8vgiG/Rz+qYDLmh5ts3e+Ln1wA9dQ+nZmVHw+RjaW3I5Ig==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-arm64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.38.tgz",
-      "integrity": "sha512-/9icXUYJWherhk+y5fjPI5yNUdFPtXHQlwP7/K/zg8t8lQdHVj20SqU9/udQmeUo5pDFHMYzcEFfJqgOVeKNNQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-32": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.38.tgz",
-      "integrity": "sha512-QfgfeNHRFvr2XeHFzP8kOZVnal3QvST3A0cgq32ZrHjSMFTdgXhMhmWdKzRXP/PKcfv3e2OW9tT9PpcjNvaq6g==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.38.tgz",
-      "integrity": "sha512-uuZHNmqcs+Bj1qiW9k/HZU3FtIHmYiuxZ/6Aa+/KHb/pFKr7R3aVqvxlAudYI9Fw3St0VCPfv7QBpUITSmBR1Q==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.38.tgz",
-      "integrity": "sha512-FiFvQe8J3VKTDXG01JbvoVRXQ0x6UZwyrU4IaLBZeq39Bsbatd94Fuc3F1RGqPF5RbIWW7RvkVQjn79ejzysnA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.38.tgz",
-      "integrity": "sha512-HlMGZTEsBrXrivr64eZ/EO0NQM8H8DuSENRok9d+Jtvq8hOLzrxfsAT9U94K3KOGk2XgCmkaI2KD8hX7F97lvA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-mips64le": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.38.tgz",
-      "integrity": "sha512-qd1dLf2v7QBiI5wwfil9j0HG/5YMFBAmMVmdeokbNAMbcg49p25t6IlJFXAeLzogv1AvgaXRXvgFNhScYEUXGQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-ppc64le": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.38.tgz",
-      "integrity": "sha512-mnbEm7o69gTl60jSuK+nn+pRsRHGtDPfzhrqEUXyCl7CTOCLtWN2bhK8bgsdp6J/2NyS/wHBjs1x8aBWwP2X9Q==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-riscv64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.38.tgz",
-      "integrity": "sha512-+p6YKYbuV72uikChRk14FSyNJZ4WfYkffj6Af0/Tw63/6TJX6TnIKE+6D3xtEc7DeDth1fjUOEqm+ApKFXbbVQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-s390x": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.38.tgz",
-      "integrity": "sha512-0zUsiDkGJiMHxBQ7JDU8jbaanUY975CdOW1YDrurjrM0vWHfjv9tLQsW9GSyEb/heSK1L5gaweRjzfUVBFoybQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-netbsd-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.38.tgz",
-      "integrity": "sha512-cljBAApVwkpnJZfnRVThpRBGzCi+a+V9Ofb1fVkKhtrPLDYlHLrSYGtmnoTVWDQdU516qYI8+wOgcGZ4XIZh0Q==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-openbsd-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.38.tgz",
-      "integrity": "sha512-CDswYr2PWPGEPpLDUO50mL3WO/07EMjnZDNKpmaxUPsrW+kVM3LoAqr/CE8UbzugpEiflYqJsGPLirThRB18IQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-sunos-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.38.tgz",
-      "integrity": "sha512-2mfIoYW58gKcC3bck0j7lD3RZkqYA7MmujFYmSn9l6TiIcAMpuEvqksO+ntBgbLep/eyjpgdplF7b+4T9VJGOA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-32": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.38.tgz",
-      "integrity": "sha512-L2BmEeFZATAvU+FJzJiRLFUP+d9RHN+QXpgaOrs2klshoAm1AE6Us4X6fS9k33Uy5SzScn2TpcgecbqJza1Hjw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.38.tgz",
-      "integrity": "sha512-Khy4wVmebnzue8aeSXLC+6clo/hRYeNIm0DyikoEqX+3w3rcvrhzpoix0S+MF9vzh6JFskkIGD7Zx47ODJNyCw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-arm64": {
-      "version": "0.14.38",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.38.tgz",
-      "integrity": "sha512-k3FGCNmHBkqdJXuJszdWciAH77PukEyDsdIryEHn9cKLQFxzhT39dSumeTuggaQcXY57UlmLGIkklWZo2qzHpw==",
-      "dev": true,
-      "optional": true
-    },
-    "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
-    },
-    "estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
-    },
-    "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-      "requires": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        }
-      }
-    },
-    "fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
-      "requires": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
-    },
-    "fraction.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
-      "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "optional": true
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "requires": {
-        "is-glob": "^4.0.3"
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
-    "is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "requires": {
-        "binary-extensions": "^2.0.0"
-      }
-    },
-    "is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
-      "requires": {
-        "has": "^1.0.3"
-      }
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI= sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
-    },
-    "is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-    },
-    "lilconfig": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
-      "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg=="
-    },
-    "magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "requires": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
-    "merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
-    },
-    "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "requires": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      }
-    },
-    "mini-svg-data-uri": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
-      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg=="
-    },
-    "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
-    },
-    "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
-    },
-    "node-releases": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
-      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
-      "dev": true
-    },
-    "normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-    },
-    "normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI= sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "dev": true
-    },
-    "object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
-    },
-    "p5": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/p5/-/p5-1.4.1.tgz",
-      "integrity": "sha512-3/X+qb0bK2Cg8nuZNpZZvzxkeUSRghOf0S+l8c+U8yIkUTVSbbcV0R8y96rx3InVBVhk8cH9kFC93VlZZElqSw=="
-    },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
-    "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
-    },
-    "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
-    },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw= sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true
-    },
-    "postcss": {
-      "version": "8.4.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
-      "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
-      "requires": {
-        "nanoid": "^3.3.3",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      }
-    },
-    "postcss-import": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
-      "integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      }
-    },
-    "postcss-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.0.tgz",
-      "integrity": "sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==",
-      "requires": {
-        "camelcase-css": "^2.0.1"
-      }
-    },
-    "postcss-load-config": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
-      "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
-      "requires": {
-        "lilconfig": "^2.0.5",
-        "yaml": "^1.10.2"
-      }
-    },
-    "postcss-nested": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
-      "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
-      "requires": {
-        "postcss-selector-parser": "^6.0.6"
-      }
-    },
-    "postcss-selector-parser": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
-      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
-      "requires": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      }
-    },
-    "postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
-    },
-    "queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
-    },
-    "quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
-    },
-    "read-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q= sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
-      "requires": {
-        "pify": "^2.3.0"
-      }
-    },
-    "readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "requires": {
-        "picomatch": "^2.2.1"
-      }
-    },
-    "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-      "requires": {
-        "is-core-module": "^2.8.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      }
-    },
-    "reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
-    },
-    "rollup": {
-      "version": "2.72.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.72.1.tgz",
-      "integrity": "sha512-NTc5UGy/NWFGpSqF1lFY8z9Adri6uhyMLI6LvPAXdBKoPRFhIIiBUpt+Qg2awixqO3xvzSijjhnb4+QEZwJmxA==",
-      "dev": true,
-      "requires": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "requires": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
-    "source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
-    },
-    "source-sans-pro": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/source-sans-pro/-/source-sans-pro-3.6.0.tgz",
-      "integrity": "sha512-C1RFUGu+YASuqpgDRInTM7Y6OwqeWNOuKn7v0P/4Kh66epTI4PYWwPWP5kdA4l/VqzBAWiqoz5dk0trof73R7w=="
-    },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-    },
-    "supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
-    },
-    "tailwindcss": {
-      "version": "3.0.24",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.24.tgz",
-      "integrity": "sha512-H3uMmZNWzG6aqmg9q07ZIRNIawoiEcNFKDfL+YzOPuPsXuDXxJxB9icqzLgdzKNwjG3SAro2h9SYav8ewXNgig==",
-      "requires": {
-        "arg": "^5.0.1",
-        "chokidar": "^3.5.3",
-        "color-name": "^1.1.4",
-        "detective": "^5.2.0",
-        "didyoumean": "^1.2.2",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.2.11",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "lilconfig": "^2.0.5",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^3.0.0",
-        "picocolors": "^1.0.0",
-        "postcss": "^8.4.12",
-        "postcss-js": "^4.0.0",
-        "postcss-load-config": "^3.1.4",
-        "postcss-nested": "5.0.6",
-        "postcss-selector-parser": "^6.0.10",
-        "postcss-value-parser": "^4.2.0",
-        "quick-lru": "^5.1.1",
-        "resolve": "^1.22.0"
-      }
-    },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "requires": {
-        "is-number": "^7.0.0"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8= sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "vite": {
-      "version": "2.9.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.8.tgz",
-      "integrity": "sha512-zsBGwn5UT3YS0NLSJ7hnR54+vUKfgzMUh/Z9CxF1YKEBVIe213+63jrFLmZphgGI5zXwQCSmqIdbPuE8NJywPw==",
-      "dev": true,
-      "requires": {
-        "esbuild": "^0.14.27",
-        "fsevents": "~2.3.2",
-        "postcss": "^8.4.13",
-        "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
-      }
-    },
-    "vue": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.33.tgz",
-      "integrity": "sha512-si1ExAlDUrLSIg/V7D/GgA4twJwfsfgG+t9w10z38HhL/HA07132pUQ2KuwAo8qbCyMJ9e6OqrmWrOCr+jW7ZQ==",
-      "requires": {
-        "@vue/compiler-dom": "3.2.33",
-        "@vue/compiler-sfc": "3.2.33",
-        "@vue/runtime-dom": "3.2.33",
-        "@vue/server-renderer": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-    },
-    "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     }
   }
 }

--- a/vendor/45drives/cockpit-hardware/45drives-disks/package.json
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/package.json
@@ -8,7 +8,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@45drives/cockpit-css": "^0.1.12",
     "@fontsource/red-hat-text": "^4.5.4",
     "@headlessui/vue": "^1.5.0",
     "@heroicons/vue": "^1.0.6",
@@ -18,7 +17,6 @@
     "vue": "^3.2.25"
   },
   "devDependencies": {
-    "@45drives/cockpit-helpers": "^0.1.9",
     "@vitejs/plugin-vue": "^2.2.0",
     "autoprefixer": "10.4.5",
     "postcss": "^8.4.12",

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/App.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/App.vue
@@ -15,6 +15,7 @@ import {
   FIFO,
 } from "@45drives/cockpit-helpers";
 import ZfsSection from "./components/ZfsSection.vue";
+import StorageSection from "./components/StorageSection.vue";
 import Notifications from "./components/Notifications.vue";
 
 export default {
@@ -27,6 +28,7 @@ export default {
     CanvasSection,
     ErrorMessage,
     ZfsSection,
+    StorageSection,
     Notifications,
   },
   props: { notificationFIFO: FIFO },
@@ -55,9 +57,31 @@ export default {
         currentDisk.value
       );
     });
+    const selectedDiskHasStoragePool = computed(() => {
+      if (!currentDisk.value || !diskInfo.rows) {
+        return false;
+      }
+
+      const slot = diskInfo.rows
+        .flat()
+        .find((disk) => disk?.["bay-id"] === currentDisk.value);
+
+      return (
+        slot?.["storage-role"] === "pool" &&
+        !!slot?.["storage-label"] &&
+        !selectedDiskHasZfs.value
+      );
+    });
+    const selectedDiskHasDetailCard = computed(
+      () => selectedDiskHasZfs.value || selectedDiskHasStoragePool.value
+    );
     const activePageLayout = computed(() => {
-      if (selectedDiskHasZfs.value) {
+      if (selectedDiskHasDetailCard.value && pageLayout.value.includes("Z")) {
         return pageLayout.value;
+      }
+
+      if (selectedDiskHasDetailCard.value) {
+        return `${pageLayout.value.replace("Z", "")}Z`;
       }
 
       return pageLayout.value.replace("Z", "");
@@ -586,6 +610,8 @@ export default {
       pageLayout,
       activePageLayout,
       selectedDiskHasZfs,
+      selectedDiskHasStoragePool,
+      selectedDiskHasDetailCard,
       notifications,
     };
   },
@@ -669,10 +695,9 @@ export default {
         <div
           v-if="
             preloadChecks.zfs.finished &&
-            !preloadChecks.zfs.failed &&
             !preloadChecks.serverInfo.failed &&
             !preloadChecks.diskInfo.failed &&
-            selectedDiskHasZfs &&
+            selectedDiskHasDetailCard &&
             preloadChecks.pageStatus.ready
           "
           :class="[
@@ -683,8 +708,9 @@ export default {
           ]"
         >
           <ZfsSection
-            v-if="preloadChecks.zfs.finished && !preloadChecks.zfs.failed"
+            v-if="selectedDiskHasZfs && preloadChecks.zfs.finished && !preloadChecks.zfs.failed"
           />
+          <StorageSection v-else-if="selectedDiskHasStoragePool" />
         </div>
 
         <div class="flex grow flex-col items-stretch gap-well col-span-6">
@@ -776,6 +802,11 @@ export default {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   margin: 0;
-  @apply bg-default h-full text-default;
+  /* bg-default / text-default expanded to standard utilities so this does not
+     depend on @apply-ing a custom component class (see src/lib/cockpit-css). */
+  @apply h-full bg-white text-gray-900;
+}
+.dark #app {
+  @apply bg-neutral-800 text-gray-100;
 }
 </style>

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/DiskSection.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/DiskSection.vue
@@ -162,6 +162,13 @@
 						<span v-else>N/A</span>
 					</div>
 				</div>
+				<div class="grid grid-cols-1 self-start py-1 md:py-2 px-2">
+					<div class="text-sm text-muted">Power Mode</div>
+					<div class="text-sm break-words">
+						<span v-if="diskObj['power-mode']">{{ diskObj['power-mode'] }}</span>
+						<span v-else>N/A</span>
+					</div>
+				</div>
 				<div
 					v-if="hasStorageDetails"
 					class="text-label text-default col-span-2 2xl:col-span-3 border-b-[1px] shrink-0 border-neutral-200 dark:border-neutral-700 mx-2 pt-2"

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/FfdHeader.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/FfdHeader.vue
@@ -58,7 +58,53 @@ export default {
 	},
 	setup(props) {
 		const darkMode = props.darkModeInjectionKey ?? ref(true);
+		// When embedded in the Unraid webGUI the plugin runs in a same-origin
+		// iframe. The Unraid shell's <html> (and/or <body>) carries the theme
+		// class set by ThemeHelper::getThemeHtmlClass (Theme--black / Theme--gray
+		// => dark, Theme--white / Theme--azure => light). Match it.
+		function themeDarkFrom(win) {
+			try {
+				const doc = win.document;
+				const cls =
+					(doc.documentElement.className || "") +
+					" " +
+					(doc.body ? doc.body.className : "");
+				if (/\bTheme--(black|gray|dark)\b/.test(cls)) return true;
+				if (/\bTheme--(white|azure|light)\b/.test(cls)) return false;
+			} catch (e) {
+				// cross-origin / unavailable window
+			}
+			return null;
+		}
+		function detectUnraidDark() {
+			// The themed shell may be the direct parent or several frames up, so
+			// walk the parent chain and also check the top window.
+			const wins = [];
+			try {
+				let w = window;
+				for (let i = 0; i < 6 && w.parent && w.parent !== w; i++) {
+					w = w.parent;
+					wins.push(w);
+				}
+			} catch (e) {
+				// frame access blocked
+			}
+			try {
+				if (window.top && wins.indexOf(window.top) === -1) wins.push(window.top);
+			} catch (e) {
+				// top access blocked
+			}
+			for (let i = 0; i < wins.length; i++) {
+				const r = themeDarkFrom(wins[i]);
+				if (r !== null) return r;
+			}
+			return null;
+		}
 		function getTheme() {
+			const unraidDark = detectUnraidDark();
+			if (unraidDark !== null)
+				return unraidDark;
+			// Standalone / dev fallback: OS preference, then any saved choice.
 			let prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
 			let theme = localStorage.getItem("color-theme");
 			if (theme === null)

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5F8X1.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5F8X1.vue
@@ -291,6 +291,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -313,6 +314,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -401,6 +403,7 @@ export default {
                     );
                     if (index === -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -438,6 +441,11 @@ export default {
                 diskLocations.forEach((loc) => {
                     if (loc.occupied && loc.image) {
                         p5.image(loc.image, loc.x, loc.y);
+                        if (loc.standby) {
+                          p5.noStroke();
+                          p5.fill(255, 165, 0, 80);
+                          p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5F8X2.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5F8X2.vue
@@ -451,6 +451,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -473,6 +474,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -561,6 +563,7 @@ export default {
                     );
                     if (index === -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -598,6 +601,11 @@ export default {
                 diskLocations.forEach((loc) => {
                     if (loc.occupied && loc.image) {
                         p5.image(loc.image, loc.x, loc.y);
+                        if (loc.standby) {
+                          p5.noStroke();
+                          p5.fill(255, 165, 0, 80);
+                          p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5F8X3.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5F8X3.vue
@@ -613,6 +613,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -635,6 +636,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -723,6 +725,7 @@ export default {
                     );
                     if (index === -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -760,6 +763,11 @@ export default {
                 diskLocations.forEach((loc) => {
                     if (loc.occupied && loc.image) {
                         p5.image(loc.image, loc.x, loc.y);
+                        if (loc.standby) {
+                          p5.noStroke();
+                          p5.fill(255, 165, 0, 80);
+                          p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL15.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL15.vue
@@ -235,6 +235,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -257,6 +258,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -332,6 +334,7 @@
             );
             if (index === -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -369,6 +372,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL15BEAST.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL15BEAST.vue
@@ -139,6 +139,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -161,6 +162,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -276,6 +278,7 @@
             );
             if (index === -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -310,6 +313,11 @@
               const w = loc.image.width * 1.11;
               const h = loc.image.height * 1.11;
               p5.image(loc.image, loc.x, loc.y, w, h);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, w, h - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL4.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL4.vue
@@ -122,6 +122,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -144,6 +145,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -220,6 +222,7 @@
             );
             if (index === -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -259,6 +262,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL8.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5HomeLabHL8.vue
@@ -125,6 +125,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -147,6 +148,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -222,6 +224,7 @@
             );
             if (index === -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -261,6 +264,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProfessionalPRO15.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProfessionalPRO15.vue
@@ -235,6 +235,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -257,6 +258,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -332,6 +334,7 @@
             );
             if (index === -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -369,6 +372,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProfessionalPRO4.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProfessionalPRO4.vue
@@ -122,6 +122,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -144,6 +145,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -220,6 +222,7 @@
             );
             if (index === -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -259,6 +262,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProfessionalPRO8.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProfessionalPRO8.vue
@@ -125,6 +125,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -147,6 +148,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -222,6 +224,7 @@
             );
             if (index === -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -261,6 +264,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM16.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM16.vue
@@ -122,6 +122,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -145,6 +146,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -240,6 +242,7 @@ export default {
                         (loc) => loc.BAY === slot["bay-id"]
                     );
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -273,6 +276,11 @@ export default {
                 diskLocations.forEach((loc) => {
                     if (loc.occupied && loc.image) {
                         p5.image(loc.image, loc.x, loc.y);
+                        if (loc.standby) {
+                          p5.noStroke();
+                          p5.fill(255, 165, 0, 80);
+                          p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM2.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM2.vue
@@ -104,6 +104,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -127,6 +128,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -222,6 +224,7 @@ export default {
                         (loc) => loc.BAY === slot["bay-id"]
                     );
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -255,6 +258,11 @@ export default {
                 diskLocations.forEach((loc) => {
                     if (loc.occupied && loc.image) {
                         p5.image(loc.image, loc.x, loc.y, DRAWN_WIDTH, DRAWN_HEIGHT);
+                        if (loc.standby) {
+                            p5.noStroke();
+                            p5.fill(255, 165, 0, 80);
+                            p5.rect(loc.x, loc.y, DRAWN_WIDTH, DRAWN_HEIGHT - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM32.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM32.vue
@@ -361,6 +361,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -384,6 +385,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -479,6 +481,7 @@ export default {
                         (loc) => loc.BAY === slot["bay-id"]
                     );
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -512,6 +515,11 @@ export default {
                 diskLocations.forEach((loc) => {
                     if (loc.occupied && loc.image) {
                         p5.image(loc.image, loc.x, loc.y);
+                        if (loc.standby) {
+                          p5.noStroke();
+                          p5.fill(255, 165, 0, 80);
+                          p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM8.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5ProxinatorVM8.vue
@@ -182,6 +182,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -205,6 +206,7 @@ export default {
                     );
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -300,6 +302,7 @@ export default {
                         (loc) => loc.BAY === slot["bay-id"]
                     );
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -333,6 +336,11 @@ export default {
                 diskLocations.forEach((loc) => {
                     if (loc.occupied && loc.image) {
                         p5.image(loc.image, loc.x, loc.y);
+                        if (loc.standby) {
+                          p5.noStroke();
+                          p5.fill(255, 165, 0, 80);
+                          p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorAV15.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorAV15.vue
@@ -235,6 +235,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -257,6 +258,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -332,6 +334,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -369,6 +372,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorC8.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorC8.vue
@@ -113,6 +113,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(slot.occupied);
         });
       },
@@ -130,6 +131,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(slot.occupied);
         });
       },
@@ -163,6 +165,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(slot.occupied);
         });
       };
@@ -189,6 +192,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorMI4.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorMI4.vue
@@ -86,6 +86,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(slot.occupied);
         });
       },
@@ -102,6 +103,7 @@ export default {
               (loc) => loc.BAY === slot["bay-id"]
             );
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(slot.occupied);
           });
         }
@@ -136,6 +138,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(slot.occupied);
         });
       };
@@ -162,6 +165,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorQ30.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorQ30.vue
@@ -400,6 +400,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -422,6 +423,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -458,6 +460,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -496,6 +499,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorQ30H16.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorQ30H16.vue
@@ -438,6 +438,7 @@ export default {
           );
           if(index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -461,6 +462,7 @@ export default {
           );
           if(index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -549,6 +551,7 @@ zfsAnimation(p5);
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -586,6 +589,11 @@ zfsAnimation(p5);
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorQ30H32.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorQ30H32.vue
@@ -509,6 +509,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -531,6 +532,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -621,6 +623,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -658,6 +661,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorS45.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorS45.vue
@@ -490,6 +490,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -512,6 +513,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -596,6 +598,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -633,6 +636,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorS45H16.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorS45H16.vue
@@ -557,6 +557,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -580,6 +581,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -670,6 +672,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -707,6 +710,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorS45H32.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorS45H32.vue
@@ -628,6 +628,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -650,6 +651,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -740,6 +742,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -777,6 +780,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorXL60.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorXL60.vue
@@ -608,6 +608,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -630,6 +631,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -714,6 +716,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -751,6 +754,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorXL60H16.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorXL60H16.vue
@@ -681,6 +681,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -703,6 +704,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -793,6 +795,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -835,6 +838,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorXL60H32.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StorinatorXL60H32.vue
@@ -749,6 +749,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -771,6 +772,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -861,6 +863,7 @@ export default {
           );
           if (index === -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -898,6 +901,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5Stornado.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5Stornado.vue
@@ -410,6 +410,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -432,6 +433,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -466,6 +468,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -503,6 +506,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5Stornado2U.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5Stornado2U.vue
@@ -353,6 +353,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -376,6 +377,7 @@ export default {
           );
           if (index == -1) return;
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -465,6 +467,7 @@ export default {
             (loc) => loc.BAY === slot["bay-id"]
           );
           diskLocations[index].occupied = slot.occupied;
+          diskLocations[index].standby = slot["power-mode"] === "STANDBY";
           diskLocations[index].image = getDiskImage(
             slot.occupied,
             slot["model-name"],
@@ -498,6 +501,11 @@ export default {
         diskLocations.forEach((loc) => {
           if (loc.occupied && loc.image) {
             p5.image(loc.image, loc.x, loc.y);
+            if (loc.standby) {
+              p5.noStroke();
+              p5.fill(255, 165, 0, 80);
+              p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+            }
             if (assets.loadingFlag) {
               p5.animateLoading(
                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StornadoF16.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StornadoF16.vue
@@ -235,6 +235,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -258,6 +259,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -353,6 +355,7 @@
               (loc) => loc.BAY === slot["bay-id"]
             );
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -386,6 +389,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y,DRAWN_WIDTH,DRAWN_HEIGHT);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, DRAWN_WIDTH, DRAWN_HEIGHT - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StornadoF2.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StornadoF2.vue
@@ -361,6 +361,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -384,6 +385,7 @@
             );
             if (index == -1) return;
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -479,6 +481,7 @@
               (loc) => loc.BAY === slot["bay-id"]
             );
             diskLocations[index].occupied = slot.occupied;
+            diskLocations[index].standby = slot["power-mode"] === "STANDBY";
             diskLocations[index].image = getDiskImage(
               slot.occupied,
               slot["model-name"],
@@ -512,6 +515,11 @@
           diskLocations.forEach((loc) => {
             if (loc.occupied && loc.image) {
               p5.image(loc.image, loc.x, loc.y);
+              if (loc.standby) {
+                p5.noStroke();
+                p5.fill(255, 165, 0, 80);
+                p5.rect(loc.x, loc.y, loc.image.width, loc.image.height - 14);
+              }
               if (assets.loadingFlag) {
                 p5.animateLoading(
                   loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StudioSTUDIO8.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/P5StudioSTUDIO8.vue
@@ -62,6 +62,7 @@ export default {
                     const index = diskLocations.findIndex((loc) => loc.BAY === slot["bay-id"]);
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -82,6 +83,7 @@ export default {
                     const index = diskLocations.findIndex((loc) => loc.BAY === slot["bay-id"]);
                     if (index == -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -124,6 +126,7 @@ export default {
                     const index = diskLocations.findIndex((loc) => loc.BAY === slot["bay-id"]);
                     if (index === -1) return;
                     diskLocations[index].occupied = slot.occupied;
+                    diskLocations[index].standby = slot["power-mode"] === "STANDBY";
                     diskLocations[index].image = getDiskImage(
                         slot.occupied,
                         slot["model-name"],
@@ -159,6 +162,11 @@ export default {
                         const w = loc.image.width * 2.1;
                         const h = loc.image.height * 2.49;
                         p5.image(loc.image, loc.x, loc.y, w, h);
+                        if (loc.standby) {
+                            p5.noStroke();
+                            p5.fill(255, 165, 0, 80);
+                            p5.rect(loc.x, loc.y, w, h - 14);
+                        }
                         if (assets.loadingFlag) {
                             p5.animateLoading(
                                 loc.x,

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/ServerSection.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/ServerSection.vue
@@ -194,24 +194,15 @@ export default {
 
     const updateDiskSummary = () => {
       if (lsdevJson.rows) {
-        diskCount.value = lsdevJson.rows
+        const occupiedDisks = lsdevJson.rows
           .flat()
-          .filter((slot) => slot.occupied).length;
+          .filter((slot) => slot.occupied);
 
-        // storageCapacity.value =
-        //   diskCount.value > 0
-        //     ? lsdevJson.rows
-        //         .flat()
-        //         .filter((slot) => slot.occupied)
-        //         .map((disk) => getCapacityGiB(disk.capacity))
-        //         .reduce((total, cap) => total + cap)
-        //         .toFixed(2)
-        //     : 0;
+        diskCount.value = occupiedDisks.length;
+
         storageCapacity.value =
           diskCount.value > 0
-            ? lsdevJson.rows
-              .flat()
-              .filter((slot) => slot.occupied)
+            ? occupiedDisks
               .map((disk) => getCapacityGiB(disk.capacity))
               .reduce((total, cap) => total + cap)
             : 0;
@@ -221,23 +212,25 @@ export default {
             ? (storageCapacity.value / 1000).toFixed(2).toString() + " TB"
             : storageCapacity.value.toString() + " GB";
 
+        // Spun-down drives report no temperature; exclude them so the average
+        // reflects only the drives that are actually spun up.
+        const tempReadings = occupiedDisks
+          .map((disk) => Number(disk["temp-c"]?.replace(/[^0-9]/g, "") ?? 0))
+          .filter((temp) => temp > 0);
+
         avgTemp.value =
-          diskCount.value > 0
+          tempReadings.length > 0
             ? (
-                lsdevJson.rows
-                  .flat()
-                  .filter((slot) => slot.occupied)
-                  .map((disk) =>
-                    Number(disk["temp-c"]?.replace(/[^0-9]/g, "") ?? 0)
-                  )
-                  .reduce((total, cap) => total + cap) / Number(diskCount.value)
+                tempReadings.reduce((total, cap) => total + cap) /
+                Number(tempReadings.length)
               ).toFixed(2)
             : 0;
-        
-        if(avgTemp.value === 0){
-          avgTempStr.value = "No Disks Present";
-        }
 
+        if (diskCount.value === 0) {
+          avgTempStr.value = "No Disks Present";
+        } else if (tempReadings.length === 0) {
+          avgTempStr.value = "All drives are spundown";
+        }
       }
     };
 

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/StorageSection.vue
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/StorageSection.vue
@@ -1,0 +1,129 @@
+<template>
+  <div id="storageCard" class="card grow flex flex-col">
+    <div class="card-header">
+      <h3 class="text-header text-default">Pool Information</h3>
+    </div>
+    <div
+      v-if="hasPoolInfo"
+      class="card-body overflow-y-auto grow-0 flex flex-wrap gap-12"
+    >
+      <div
+        class="grow-0 2xl:grow grid grid-cols-3 items-stretch gap-y-3 gap-x-5"
+      >
+        <div
+          class="text-label text-default col-span-3 border-b-[1px] shrink-0 border-neutral-200 dark:border-neutral-700"
+        >
+          Pool
+        </div>
+        <div class="grid grid-cols-1">
+          <div class="text-sm text-muted">name</div>
+          <div class="text-sm break-words">{{ poolName }}</div>
+        </div>
+        <div class="grid grid-cols-1">
+          <div class="text-sm text-muted">filesystem</div>
+          <div class="text-sm break-words">{{ filesystem }}</div>
+        </div>
+        <div class="grid grid-cols-1">
+          <div class="text-sm text-muted">status</div>
+          <div class="text-sm break-words">{{ status }}</div>
+        </div>
+        <div class="grid grid-cols-1">
+          <div class="text-sm text-muted">mountpoint</div>
+          <div class="text-sm break-words">{{ mountpoint }}</div>
+        </div>
+        <div class="grid grid-cols-1">
+          <div class="text-sm text-muted">members</div>
+          <div class="text-sm break-words">{{ poolMembers.length }}</div>
+        </div>
+      </div>
+
+      <div
+        class="grow-0 2xl:grow grid grid-cols-3 items-stretch gap-y-3 gap-x-5"
+      >
+        <div
+          class="text-label text-default col-span-3 border-b-[1px] shrink-0 border-neutral-200 dark:border-neutral-700"
+        >
+          Devices
+        </div>
+        <div>
+          <div class="text-sm text-muted">slots</div>
+          <div class="text-sm break-words">{{ slotSummary }}</div>
+        </div>
+        <div class="col-span-2">
+          <div class="text-sm text-muted">devices</div>
+          <div class="text-sm break-words">{{ deviceSummary }}</div>
+        </div>
+      </div>
+    </div>
+    <div v-else class="card-body grow flex justify-center items-center">
+      <div class="p-5 bg-accent rounded-lg">
+        <span class="text-muted">Click on a pool disk for more detail.</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { computed, inject } from "vue";
+
+export default {
+  setup() {
+    const currentDisk = inject("currentDisk");
+    const diskInfo = inject("diskInfo");
+
+    const rows = computed(() => (diskInfo?.rows ? diskInfo.rows.flat() : []));
+    const selectedDisk = computed(() =>
+      rows.value.find((slot) => slot?.["bay-id"] === currentDisk.value)
+    );
+    const poolName = computed(() => selectedDisk.value?.["storage-label"] || "N/A");
+    const hasPoolInfo = computed(
+      () =>
+        selectedDisk.value?.["storage-role"] === "pool" &&
+        !!selectedDisk.value?.["storage-label"]
+    );
+    const poolMembers = computed(() => {
+      if (!hasPoolInfo.value) return [];
+      return rows.value.filter(
+        (slot) =>
+          slot?.["storage-role"] === "pool" &&
+          slot?.["storage-label"] === selectedDisk.value["storage-label"]
+      );
+    });
+    const firstValue = (key) => {
+      const match = poolMembers.value.find((slot) => slot?.[key]);
+      return match?.[key] || "N/A";
+    };
+    const uniqueValues = (key) =>
+      Array.from(
+        new Set(poolMembers.value.map((slot) => slot?.[key]).filter(Boolean))
+      );
+    const filesystem = computed(() => {
+      const values = uniqueValues("fs-type");
+      return values.length ? values.join(", ") : "N/A";
+    });
+    const status = computed(() => firstValue("fs-status"));
+    const mountpoint = computed(() => firstValue("fs-mountpoint"));
+    const slotSummary = computed(() => {
+      const values = poolMembers.value.map((slot) => slot?.["bay-id"]).filter(Boolean);
+      return values.length ? values.join(", ") : "N/A";
+    });
+    const deviceSummary = computed(() => {
+      const values = poolMembers.value
+        .map((slot) => slot?.dev || slot?.["dev-by-path"])
+        .filter(Boolean);
+      return values.length ? values.join(", ") : "N/A";
+    });
+
+    return {
+      hasPoolInfo,
+      poolName,
+      poolMembers,
+      filesystem,
+      status,
+      mountpoint,
+      slotSummary,
+      deviceSummary,
+    };
+  },
+};
+</script>

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/components/zfsAnimation.js
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/components/zfsAnimation.js
@@ -120,6 +120,36 @@ export default function zfsAnimation(p5) {
     return true;
   };
 
+  // Highlight the other members of a disk's storage group. Guards against
+  // members that aren't mapped to a physical bay (non-slot devices), which
+  // previously errored on diskLocations[-1].
+  p5.showStorageGroupPeers = (cd, animationInfo, diskLocations, y_offset = 0) => {
+    const currentDisk = animationInfo?.animation_disks?.[cd];
+    const group = animationInfo?.animation_groups?.[currentDisk?.group] || [];
+    if (!currentDisk || group.length < 2) {
+      return false;
+    }
+    group.forEach((dsk) => {
+      const diskName = dsk?.name || dsk;
+      if (diskName === cd) return;
+      const dsk_idx = diskLocations.findIndex((loc) => loc.BAY === diskName);
+      if (dsk_idx < 0 || !diskLocations[dsk_idx]?.image) return;
+      const loc = diskLocations[dsk_idx];
+      p5.animateZpools(
+        loc.x,
+        loc.y,
+        loc.image.width,
+        loc.image.height + y_offset,
+        p5.zfsAnimationSteps,
+        p5.zfsAnimationIndex,
+        p5.zfsAnimationColors.storage_group.start,
+        p5.zfsAnimationColors.storage_group.end,
+        p5.zfsAnimationDir
+      );
+    });
+    return true;
+  };
+
   p5.showAnimations = (cd, zfsInfo, diskLocations, y_offset = 0) => {
     if (zfsInfo.zfs_installed) {
       //zfs is installed
@@ -210,6 +240,7 @@ export default function zfsAnimation(p5) {
               }
             });
           });
+          p5.showStorageGroupPeers(cd, zfsInfo, diskLocations, y_offset);
           return true;
         }
       }

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/lib/cockpit-css/entry.css
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/lib/cockpit-css/entry.css
@@ -1,0 +1,13 @@
+/*
+ * Vendored reconstruction of @45drives/cockpit-css (compiled entrypoint).
+ *
+ * main.js imports the package's `dist/index.css`, which is aliased here. The
+ * full Tailwind entrypoint and the 45Drives design-token layer live in
+ * ./index.css, which App.vue imports and which is therefore emitted globally
+ * for the whole app. Tailwind's @layer directives must sit alongside the
+ * @tailwind directives in one file, and emitting that file from both entry
+ * points doubles the generated CSS, so this entry is intentionally empty and
+ * only keeps the import path valid.
+ *
+ * See ./index.css for the token definitions and provenance.
+ */

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/lib/cockpit-css/index.css
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/lib/cockpit-css/index.css
@@ -1,0 +1,164 @@
+/*
+ * Vendored reconstruction of @45drives/cockpit-css.
+ *
+ * The upstream package is published only to 45Drives' private GitHub Packages
+ * registry, so the project could not be built without credentials. This file
+ * reproduces the pieces the app actually relies on:
+ *
+ *   1. The Tailwind entrypoint (@tailwind base/components/utilities) — the app
+ *      has no @tailwind directives of its own; they lived inside cockpit-css.
+ *   2. The 45Drives design-token layer (bg-default, text-default, card, well,
+ *      etc.), with light/dark and responsive variants.
+ *
+ * Token values were recovered from the shipped compiled stylesheet
+ * (assets/45d/45drives-disks/assets/index.c1d0ecce.css) so they match what the
+ * plugin renders today. Authored cleanly with Tailwind @apply rather than
+ * reproducing the legacy build's quirks.
+ */
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer components {
+  /* Backgrounds */
+  .bg-default {
+    @apply bg-white dark:bg-neutral-800;
+  }
+  :is(button, a, .btn).bg-default:hover,
+  .bg-default.interactive:hover {
+    @apply bg-neutral-100 dark:bg-neutral-850;
+  }
+  .bg-accent {
+    @apply bg-neutral-100 dark:bg-[#333333];
+  }
+  .bg-plugin-header {
+    @apply bg-white dark:bg-neutral-800;
+  }
+
+  /* Text and icons */
+  .text-default {
+    @apply text-gray-900 dark:text-gray-100;
+  }
+  .text-muted {
+    @apply text-gray-500;
+  }
+  .dark .bg-accent .text-muted,
+  .dark .text-muted.bg-accent {
+    @apply text-gray-400;
+  }
+  .text-secondary {
+    @apply text-slate-500;
+  }
+  :is(button, a, .btn).text-secondary:hover,
+  .text-secondary.interactive:hover {
+    @apply text-slate-600;
+  }
+  .text-primary {
+    @apply text-slate-600;
+  }
+  :is(button, a, .btn).text-primary:hover,
+  .text-primary.interactive:hover {
+    @apply text-slate-700;
+  }
+  .icon-default {
+    @apply text-gray-500;
+  }
+  :is(button, a) > .icon-default:hover,
+  .btn.icon-default:hover,
+  .icon-default.interactive:hover {
+    @apply text-gray-600;
+  }
+  button:disabled > .icon-default {
+    @apply cursor-no-drop text-neutral-400 dark:text-neutral-600;
+  }
+
+  /* Text size and weight */
+  .text-header {
+    @apply text-lg font-semibold;
+  }
+
+  /* Icons */
+  .size-icon {
+    height: 1.25rem;
+    width: auto;
+  }
+  .size-icon-lg {
+    height: 1.75rem;
+    width: auto;
+  }
+
+  /* Divide and border */
+  .divide-default > :not([hidden]) ~ :not([hidden]) {
+    @apply border-neutral-200 dark:border-neutral-700;
+  }
+
+  /* Combination classes */
+  .card {
+    @apply bg-white shadow-md dark:bg-neutral-800 md:shadow-lg;
+  }
+  :is(button, a, .btn).card:hover,
+  .card.interactive:hover {
+    @apply bg-neutral-100 dark:bg-neutral-850;
+  }
+  .card > :not([hidden]) ~ :not([hidden]) {
+    @apply divide-y divide-neutral-200 dark:divide-neutral-700;
+  }
+  .card-body {
+    @apply px-4 py-5 md:px-6;
+  }
+  .card-header {
+    @apply px-4 py-2 md:px-6 md:py-5;
+  }
+  .well {
+    @apply gap-4 bg-neutral-200 p-2 dark:bg-neutral-900 md:p-8;
+  }
+
+  /* Feedback text */
+  .text-label {
+    @apply mb-1 text-sm font-semibold;
+  }
+  .text-danger {
+    @apply text-rose-500 dark:text-rose-700;
+  }
+  :is(button, a, .btn).text-danger:hover,
+  .text-danger.interactive:hover {
+    @apply text-rose-600 dark:text-rose-800;
+  }
+  .text-success {
+    @apply text-green-600 dark:text-green-500;
+  }
+  :is(button, a, .btn).text-success:hover,
+  .text-success.interactive:hover {
+    @apply text-green-700 dark:text-green-600;
+  }
+  .text-warning {
+    @apply text-orange-500;
+  }
+  :is(button, a, .btn).text-warning:hover,
+  .text-warning.interactive:hover {
+    @apply text-orange-600;
+  }
+
+  /* Feedback icons */
+  .icon-success {
+    @apply text-green-500;
+  }
+  .icon-warning {
+    @apply text-yellow-400;
+  }
+  .icon-error {
+    @apply text-red-600;
+  }
+  .icon-info {
+    @apply text-blue-500;
+  }
+
+  /* Spacing */
+  .gap-well {
+    @apply gap-4;
+  }
+  .space-y-content {
+    @apply space-y-4;
+  }
+}

--- a/vendor/45drives/cockpit-hardware/45drives-disks/src/lib/cockpitHelpers.js
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/src/lib/cockpitHelpers.js
@@ -1,0 +1,121 @@
+// Vendored subset of @45drives/cockpit-helpers.
+//
+// The upstream package is published only to 45Drives' private GitHub Packages
+// registry, which makes the project impossible to build without registry
+// credentials. This app only uses the five helpers below, all of which depend
+// solely on Vue reactivity and the global `cockpit` object, so we vendor them
+// here and drop the private dependency. Implementations mirror the published
+// package (extracted from the compiled bundle).
+
+import { reactive, watch } from "vue";
+
+export function errorString(state) {
+  if (typeof state === "string") return state;
+  return state?.stderr ?? state?.message ?? JSON.stringify(state);
+}
+
+export function errorStringHTML(state) {
+  if (typeof state === "string")
+    return `<span class="text-gray-500 font-mono text-sm whitespace-pre-wrap">${state}</span>`;
+  return (
+    state.errorStringHTML?.call(state) ??
+    `<span class="text-gray-500 font-mono text-sm whitespace-pre-wrap">${state?.stderr ?? state?.message ?? JSON.stringify(state)}</span>`
+  );
+}
+
+export function useSpawn(argv = [], opts = {}, stderr = "message") {
+  const state = reactive({
+    loading: true,
+    status: 0,
+    stdout: "",
+    stderr: "",
+    argv: [],
+    proc: null,
+    promise() {
+      return new Promise((resolve, reject) => {
+        watch(
+          state,
+          () => {
+            if (!state.loading) {
+              if (state.status === 0) resolve({ ...state });
+              else reject({ ...state });
+            }
+          },
+          { lazy: false, immediate: true }
+        );
+      });
+    },
+    argvPretty() {
+      return argv.map((token) => (/\s/.test(token) ? `"${token}"` : token)).join(" ");
+    },
+    errorStringHTML(fullArgv = false) {
+      return (
+        `<span class="font-mono text-sm whitespace-pre-wrap"><span class="font-semibold">${this.argv[0]}: </span><span>${errorString(this)} </span>` +
+        (fullArgv ? `<span class="text-gray-500 font-mono text-sm">${this.argvPretty()}</span>` : "") +
+        "</span>"
+      );
+    },
+  });
+
+  if (!opts.superuser) opts.superuser = "require";
+  if (!opts.err) opts.err = stderr;
+
+  state.loading = true;
+  state.status = 0;
+  state.stdout = "";
+  state.stderr = "";
+  state.argv = [...argv];
+  state.proc = cockpit.spawn(argv, opts);
+  state.proc
+    .then((_stdout, _stderr) => {
+      state.stdout = _stdout;
+      state.stderr = _stderr;
+    })
+    .catch((ex, _stdout) => {
+      state.stdout = _stdout;
+      state.stderr = ex.message ?? ex.problem;
+      state.status = ex.exit_status;
+    })
+    .finally(() => {
+      state.loading = false;
+    });
+
+  return state;
+}
+
+export class FIFO {
+  constructor() {
+    this.arr = [];
+    this.len = 0;
+  }
+  push(obj) {
+    this.len++;
+    this.arr.push(obj);
+  }
+  pop() {
+    const obj = this.arr.shift() ?? null;
+    if (obj) this.len--;
+    return obj;
+  }
+  getLen() {
+    return this.len;
+  }
+}
+
+export class UniqueIDGenerator {
+  constructor(maxIds = Number.MAX_SAFE_INTEGER) {
+    this.id = 0;
+    this.maxIds = maxIds;
+    this.reuptake = [];
+  }
+  get() {
+    if (this.id == this.maxIds && this.reuptake.length === 0)
+      throw new Error("Unique ID limit reached");
+    return this.reuptake.length ? this.reuptake.shift() : this.id++;
+  }
+  release(id) {
+    if (this.reuptake.includes(id)) throw new Error("Double release of unique ID");
+    if (id >= this.id) throw new Error("Released ID was never given");
+    this.reuptake.push(id);
+  }
+}

--- a/vendor/45drives/cockpit-hardware/45drives-disks/vite.config.js
+++ b/vendor/45drives/cockpit-hardware/45drives-disks/vite.config.js
@@ -1,10 +1,24 @@
 import { defineConfig } from 'vite'
+import { fileURLToPath, URL } from 'node:url'
 import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
   base: "./",
+  resolve: {
+    alias: {
+      // Vendored locally so the project builds without 45Drives' private
+      // GitHub Packages registry. See src/lib/ for the reconstructions.
+      '@45drives/cockpit-helpers': fileURLToPath(new URL('./src/lib/cockpitHelpers.js', import.meta.url)),
+      // App.vue imports .../src/index.css (the full Tailwind entrypoint + tokens);
+      // main.js imports .../dist/index.css, aliased to an empty entry so Tailwind
+      // is not emitted twice. Neither lives under a `dist/` dir (which .gitignore
+      // would swallow).
+      '@45drives/cockpit-css/src/index.css': fileURLToPath(new URL('./src/lib/cockpit-css/index.css', import.meta.url)),
+      '@45drives/cockpit-css/dist/index.css': fileURLToPath(new URL('./src/lib/cockpit-css/entry.css', import.meta.url)),
+    },
+  },
   build:{
     minify: false,
   }


### PR DESCRIPTION
Consolidates the previously-stacked PRs (#12, #14, #15, #16) into one clean **source** PR on top of current `main` (which already has the header fix #13). **Vendor source only — the committed bundle is unchanged, so this does not alter what ships.** The regenerated bundle that actually delivers these features follows in a stacked PR.

### Commits
1. **chore(build): vendor @45drives deps** — reconstructs `cockpit-helpers` (5 utils) and `cockpit-css` (Tailwind entrypoint + design tokens), both previously only on 45Drives' private registry, under `src/lib` + vite aliases. `npm install && vite build` now works with only public packages.
2. **feat(ui): port drive-standby / power-mode to source** — spundown-aware avg temp + "All drives are spundown" (ServerSection), Power Mode field (DiskSection), orange standby overlay across all 31 P5 canvases. (Was only hand-patched into the bundle.)
3. **feat(ui): match Unraid's light/dark color mode** — detect Unraid's theme from the webGUI shell and match it.
4. **feat(ui): storage-pool detail card** — StorageSection card for non-ZFS pool members.

### Verification
- `npm install` succeeds with only public packages; `vite build` builds cleanly.
- Built bundle contains all features (theme/standby/storage); CSS reconstruction validated value-for-value against the original (26 design tokens + 10 feedback classes).

### Notes
- Replaces #12/#14/#15/#16 (to be closed).
- The committed `assets/` bundle and `drivemap.js` are intentionally untouched here — they're in the follow-up bundle PR.
- ⚠️ Theme-matching is pending a final on-device re-test (the earlier console check was run from the wrong frame); it falls back to OS preference if detection fails.