### PR TITLE
fix(plg): stop install from corrupting system directory perms

### DIFF
--- a/45d-drivemap.plg.template
+++ b/45d-drivemap.plg.template
@@ -35,7 +35,17 @@ mkdir -p /var/local/45d
 
 if [ -f "${PACKAGE_FILE}" ]; then
   rm -rf "${PLUGIN_DIR}"
-  tar --no-overwrite-dir -xf "${PACKAGE_FILE}" -C /
+  # Extract only into the plugin tree without touching the metadata of the
+  # system directories that lead to it:
+  #   --no-same-owner       extract as root; never apply the archive's stored
+  #                         uid/gid to /, /usr, ... (a bad/old package once
+  #                         stamped build-side ownership onto '/', which broke
+  #                         sshd StrictModes: "bad ownership or modes for
+  #                         directory /").
+  #   --no-same-permissions don't apply the archive's modes to those dirs.
+  #   --no-overwrite-dir    leave existing directory metadata untouched.
+  tar --no-same-owner --no-same-permissions --no-overwrite-dir \
+    -xf "${PACKAGE_FILE}" -C /
 fi
 
 chmod +x "${PLUGIN_DIR}/scripts/45d-generate-map" || true


### PR DESCRIPTION
## Problem
The plugin install extracts its package with `tar ... -C /`. The archive carries parent-directory entries (`/usr`, `/usr/local`, …), so extraction can stamp **build-side ownership/modes onto real system directories**. On at least one box an older package did this to **`/` itself**, which broke SSH — sshd's StrictModes refused logins with:

```
Authentication refused: bad ownership or modes for directory /
```

## Fix (install side — `45d-drivemap.plg.template`)
Extract with **`--no-same-owner --no-same-permissions --no-overwrite-dir`** so the archive's stored uid/gid/modes are never applied to existing system directories. New plugin files are written as `root` with umask modes; existing directory metadata (`/`, `/usr`, …) is left untouched.

## Why not the build script
`scripts/build-plugin-txz` is already hardened — it normalizes tar ownership to `root` (`--owner=0 --group=0` / `--uid 0 --gid 0`) and rejects a `./` root entry. So current packages are clean; the damage came from an **older** package. This PR closes the install side.

## Verification
- The install `<INLINE>` script passes `bash -n`.
- Standalone change — touches only `45d-drivemap.plg.template`; independent of the other open PRs.