### PR TITLE
fix(Systems) Add support for HL-15 1.0 and 2.0

### DIFF
--- a/scripts/45d-generate-map
+++ b/scripts/45d-generate-map
@@ -541,7 +541,7 @@ function smart_data($dev_path, $smartctl_dir, $smartctl_nocheck)
     return null;
   }
 
-  $standby_detected = (bool)preg_match('/device\s+is\s+in\s+(standby|sleep)\s+mode/i', $output);
+  $standby_detected = (bool)preg_match('/device\s+is\s+in\s+(?:standby|sleep)(?:\s+\S+)*\s+mode/i', $output);
 
   $decoded = decode_json_loose($output);
   if (!is_array($decoded)) {

--- a/scripts/45d-generate-server-info
+++ b/scripts/45d-generate-server-info
@@ -7,6 +7,7 @@ $output_file = getenv('DRIVEMAP_SERVER_INFO_OUTPUT') ?: ($output_dir . '/server_
 $source_file = getenv('DRIVEMAP_SERVER_INFO_INPUT') ?: '/etc/45drives/server_info/server_info.json';
 $vendor_server_identifier = getenv('DRIVEMAP_VENDOR_SERVER_IDENTIFIER') ?: '/opt/45drives/tools/server_identifier';
 $alias_file = getenv('DRIVEMAP_ALIAS_FILE') ?: '/etc/vdev_id.conf';
+$plugin_config_dir = rtrim(getenv('DRIVEMAP_PLUGIN_CONFIG_DIR') ?: '/boot/config/plugins/45d-drivemap', "/\\");
 $force_model = getenv('DRIVEMAP_SERVER_MODEL') ?: '';
 $force_chassis = getenv('DRIVEMAP_CHASSIS_SIZE') ?: '';
 $force_alias = getenv('DRIVEMAP_ALIAS_STYLE') ?: '';
@@ -37,6 +38,15 @@ function read_first_value($paths)
   }
   return '';
 }
+
+function product_name_value($value)
+{
+  return trim(str_replace(["\r", "\n"], '', (string)$value));
+}
+
+$product_name_file_override = product_name_value(read_first_value([
+  $plugin_config_dir . '/product_name',
+]));
 
 function alias_templates()
 {
@@ -427,10 +437,16 @@ if (is_executable($vendor_server_identifier)) {
   }
 }
 
-$product_name = $product_name_override !== '' ? $product_name_override : read_first_value([
-  '/sys/class/dmi/id/product_name',
-  '/sys/class/dmi/id/board_name',
-]);
+$product_name = product_name_value($product_name_override);
+if ($product_name === '') {
+  $product_name = $product_name_file_override;
+}
+if ($product_name === '') {
+  $product_name = product_name_value(read_first_value([
+    '/sys/class/dmi/id/product_name',
+    '/sys/class/dmi/id/board_name',
+  ]));
+}
 $board_name = $board_name_override !== '' ? $board_name_override : read_first_value([
   '/sys/class/dmi/id/board_name',
   '/sys/class/dmi/id/product_name',

--- a/scripts/45d-generate-server-info
+++ b/scripts/45d-generate-server-info
@@ -346,7 +346,7 @@ function hardware_profile($product_name, $board_name, $hbas)
       'prefix' => 'HomeLab',
       'style' => 'HOMELAB',
       'chassis' => 'HL15',
-      'model' => '45Homelab HL-15 1.0',
+      'model' => '45Homelab HL-15',
     ];
   }
   return null;

--- a/scripts/45d-generate-server-info
+++ b/scripts/45d-generate-server-info
@@ -307,6 +307,22 @@ function hardware_profile($product_name, $board_name, $hbas)
         'model' => 'Unraid >< 45Homelab X-15',
       ];
     }
+    if ($name === 'ROMED8-2T' && count_hbas_by_connections($hbas, 16) === 1 && count_hbas_by_connections($hbas, 24) === 0) {
+      return [
+        'prefix' => 'HomeLab',
+        'style' => 'HOMELAB',
+        'chassis' => 'HL15',
+        'model' => '45Homelab HL-15 2.0',
+      ];
+    }
+    if ($name === 'X11SPH-NCTF' && count_hbas_by_connections($hbas, 16) === 1 && count_hbas_by_connections($hbas, 24) === 0) {
+      return [
+        'prefix' => 'HomeLab',
+        'style' => 'HOMELAB',
+        'chassis' => 'HL15',
+        'model' => '45Homelab HL-15 1.0',
+      ];
+    }
   }
   return null;
 }

--- a/scripts/45d-generate-server-info
+++ b/scripts/45d-generate-server-info
@@ -297,32 +297,47 @@ function count_hbas_by_connections($hbas, $connections)
 
 function hardware_profile($product_name, $board_name, $hbas)
 {
-  $names = array_filter([$product_name, $board_name], fn($value) => is_string($value) && $value !== '');
+  $names = array_filter([$board_name, $product_name], fn($value) => is_string($value) && $value !== '');
+  $has_name = fn($candidates) => (bool)array_intersect($names, (array)$candidates);
+  $has_romed8 = false;
   foreach ($names as $name) {
-    if ($name === 'MW34-SP0-00' && count_hbas_by_connections($hbas, 16) === 1 && count_hbas_by_connections($hbas, 24) === 0) {
-      return [
-        'prefix' => 'HomeLab',
-        'style' => 'HOMELAB',
-        'chassis' => 'HL15',
-        'model' => 'Unraid >< 45Homelab X-15',
-      ];
+    if (preg_match('/^ROMED8-2T(?:\/.*)?$/', $name)) {
+      $has_romed8 = true;
+      break;
     }
-    if ($name === 'ROMED8-2T' && count_hbas_by_connections($hbas, 16) === 1 && count_hbas_by_connections($hbas, 24) === 0) {
-      return [
-        'prefix' => 'HomeLab',
-        'style' => 'HOMELAB',
-        'chassis' => 'HL15',
-        'model' => '45Homelab HL-15 2.0',
-      ];
-    }
-    if ($name === 'X11SPH-NCTF' && count_hbas_by_connections($hbas, 16) === 1 && count_hbas_by_connections($hbas, 24) === 0) {
-      return [
-        'prefix' => 'HomeLab',
-        'style' => 'HOMELAB',
-        'chassis' => 'HL15',
-        'model' => '45Homelab HL-15 1.0',
-      ];
-    }
+  }
+
+  if ($has_name('MW34-SP0-00') && count_hbas_by_connections($hbas, 16) === 1 && count_hbas_by_connections($hbas, 24) === 0) {
+    return [
+      'prefix' => 'HomeLab',
+      'style' => 'HOMELAB',
+      'chassis' => 'HL15',
+      'model' => 'Unraid >< 45Homelab X-15',
+    ];
+  }
+  if ($has_name(['X11SPH-nCTF', 'X11SPH-nCTPF']) && count_hbas_by_connections($hbas, 16) === 1 && count_hbas_by_connections($hbas, 24) === 0) {
+    return [
+      'prefix' => 'HomeLab',
+      'style' => 'HOMELAB',
+      'chassis' => 'HL15',
+      'model' => '45Homelab HL-15 1.0',
+    ];
+  }
+  if ($has_romed8 && count_hbas_by_connections($hbas, 16) === 1 && count_hbas_by_connections($hbas, 24) === 0) {
+    return [
+      'prefix' => 'HomeLab',
+      'style' => 'HOMELAB',
+      'chassis' => 'HL15',
+      'model' => '45Homelab HL-15 2.0',
+    ];
+  }
+  if ($has_name('HL15')) {
+    return [
+      'prefix' => 'HomeLab',
+      'style' => 'HOMELAB',
+      'chassis' => 'HL15',
+      'model' => '45Homelab HL-15 1.0',
+    ];
   }
   return null;
 }
@@ -430,9 +445,9 @@ $serial = $force_serial !== '' ? $force_serial : read_first_value([
   '/sys/class/dmi/id/board_serial',
 ]);
 $hbas = detect_hbas(lspci_verbose_output($lspci_verbose_override));
-$prefix = $force_prefix !== '' ? $force_prefix : infer_prefix($product_name);
-$layout = infer_layout_from_aliases($alias_file, $prefix);
 $profile = hardware_profile($product_name, $board_name, $hbas);
+$prefix = $force_prefix !== '' ? $force_prefix : ($profile['prefix'] ?? infer_prefix($product_name));
+$layout = infer_layout_from_aliases($alias_file, $prefix);
 
 $chassis = $force_chassis !== '' ? $force_chassis : ($layout['chassis'] !== '' ? $layout['chassis'] : ($profile['chassis'] ?? '?'));
 $alias_style = $force_alias !== '' ? strtoupper($force_alias) : ($layout['style'] !== '' ? $layout['style'] : ($profile['style'] ?? 'STORINATOR'));

--- a/tests/fixtures/smart/sdc.json
+++ b/tests/fixtures/smart/sdc.json
@@ -1,18 +1,17 @@
 {
-  "model_name": "HGST HUH721212ALN",
-  "serial_number": "SAMPLE0003",
-  "user_capacity": { "bytes": 1099511627776 },
-  "firmware_version": "A3J0",
-  "rotation_rate": 7200,
-  "ata_smart_attributes": {
-    "table": [
-      {"name": "Start_Stop_Count", "raw": {"string": "1"}},
-      {"name": "Power_Cycle_Count", "raw": {"string": "2"}},
-      {"name": "Temperature_Celsius", "raw": {"string": "33"}},
-      {"name": "Current_Pending_Sector", "raw": {"string": "0"}},
-      {"name": "Offline_Uncorrectable", "raw": {"string": "0"}}
-    ]
+  "smartctl": {
+    "messages": [
+      {
+        "string": "Device is in STANDBY BY COMMAND mode, exit(2)",
+        "severity": "information"
+      }
+    ],
+    "exit_status": 2
   },
-  "power_on_time": {"hours": 2000},
-  "smart_status": {"passed": true}
+  "device": {
+    "name": "/dev/sdc",
+    "info_name": "/dev/sdc",
+    "type": "scsi",
+    "protocol": "SCSI"
+  }
 }

--- a/tests/run.php
+++ b/tests/run.php
@@ -607,8 +607,10 @@ $smart_map = load_json_file($ctx['out_dir'] . '/drivemap.json');
 assert_true(is_array($smart_map), 'smart map parses as JSON');
 $smart_1_1 = find_slot($smart_map['rows'] ?? [], '1-1');
 $smart_1_2 = find_slot($smart_map['rows'] ?? [], '1-2');
+$smart_2_1 = find_slot($smart_map['rows'] ?? [], '2-1');
 assert_true(is_array($smart_1_1), 'smart slot 1-1 exists');
 assert_true(is_array($smart_1_2), 'smart slot 1-2 exists');
+assert_true(is_array($smart_2_1), 'smart slot 2-1 exists');
 assert_equal($smart_1_1['model-family'] ?? '', 'Seagate Exos X16', 'smart model-family from fixture');
 assert_equal($smart_1_1['firm-ver'] ?? '', 'SC60', 'smart firmware from fixture');
 assert_equal($smart_1_1['start-stop-count'] ?? '', '12', 'smart start-stop count');
@@ -617,6 +619,7 @@ assert_equal($smart_1_1['temp-c'] ?? '', '35 C', 'smart ata temperature');
 assert_equal($smart_1_1['health'] ?? '', 'OK', 'smart health');
 assert_equal($smart_1_1['power-on-time'] ?? '', '12345', 'smart power on time');
 assert_equal($smart_1_2['temp-c'] ?? '', '30 C', 'smart non-ata temperature');
+assert_equal($smart_2_1['power-mode'] ?? '', 'STANDBY', 'smart sas standby by command power mode');
 
 // Scenario 3: H16/Q30 row parity against upstream lsdev alias_template.
 $ctx_h16_q30 = create_context('h16q30');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded server hardware detection with stronger product-name normalization and improved model/variant matching to select the correct HomeLab profile, prefix, and layout.
* **Bug Fixes**
  * Improved SMART output parsing to more reliably detect drives in standby/sleep and set `power-mode` to `STANDBY`.
* **Tests**
  * Refreshed SMART fixtures and strengthened coverage by validating slot bay `2-1` is present and has `power-mode` set to `STANDBY`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->